### PR TITLE
Add status accumulator metadata for status skills

### DIFF
--- a/Assets/Scripts/TGD.Combat/EffectInterpreter.cs
+++ b/Assets/Scripts/TGD.Combat/EffectInterpreter.cs
@@ -720,22 +720,37 @@ namespace TGD.Combat
                 Condition = effect.condition
             };
 
-            if (isInstant && !string.IsNullOrWhiteSpace(statusSkillId) && context.SkillResolver != null)
+            SkillDefinition statusSkill = null;
+            if (!string.IsNullOrWhiteSpace(statusSkillId) && context.SkillResolver != null)
             {
-                var statusSkill = context.SkillResolver.FindSkill(statusSkillId);
+                statusSkill = context.SkillResolver.FindSkill(statusSkillId);
+                var accumulatorPreview = BuildStatusAccumulatorPreview(statusSkill);
+                if (accumulatorPreview != null)
+                    preview.Accumulator = accumulatorPreview;
+            }
+
+            if (isInstant)
+            {
                 if (statusSkill != null)
                 {
                     var childContext = context.CloneForSkill(statusSkill, inheritSkillLevelOverride: false);
                     preview.InstantResult = InterpretSkillInternal(childContext, visited);
                     result.Append(preview.InstantResult);
                 }
-                else
+                else if (!string.IsNullOrWhiteSpace(statusSkillId))
                 {
                     result.AddLog($"Status skill '{statusSkillId}' not found for ModifyStatus apply effect.");
                 }
             }
 
             result.StatusApplications.Add(preview);
+
+            if (preview.Accumulator != null)
+            {
+                string accumulatorLog = BuildStatusAccumulatorLog(statusSkillId, preview.Accumulator);
+                if (!string.IsNullOrEmpty(accumulatorLog))
+                    result.AddLog(accumulatorLog);
+            }
             string action = isInstant ? "Trigger" : "Apply";
 
             string stackLabel = stacks > 0 ? $"{stacks} stack(s)" : "(no stacks)";
@@ -752,6 +767,68 @@ namespace TGD.Combat
 
             string durationSuffix = string.IsNullOrEmpty(durationLabel) ? string.Empty : $" {durationLabel}";
             result.AddLog($"{action} status '{statusSkillId}' ({stackLabel}){durationSuffix} ({probability:0.##}% chance).");
+        }
+
+        private static StatusAccumulatorPreview BuildStatusAccumulatorPreview(SkillDefinition statusSkill)
+        {
+            if (statusSkill?.statusMetadata == null)
+                return null;
+
+            var settings = statusSkill.statusMetadata.accumulatorSettings;
+            if (settings == null || !settings.enabled)
+                return null;
+
+            var preview = new StatusAccumulatorPreview
+            {
+                Source = settings.source,
+                From = settings.from,
+                Amount = settings.amount,
+                IncludeDotHot = settings.includeDotHot,
+                VariableKey = settings.GetVariableKey()
+            };
+
+            if (settings.source == StatusAccumulatorSource.DamageTaken)
+                preview.DamageSchool = settings.damageSchool;
+
+            return preview;
+        }
+
+        private static string BuildStatusAccumulatorLog(string statusSkillId, StatusAccumulatorPreview accumulator)
+        {
+            if (accumulator == null)
+                return string.Empty;
+
+            string statusLabel = string.IsNullOrWhiteSpace(statusSkillId)
+                ? "(unknown status)"
+                : $"'{statusSkillId}'";
+
+            string sourceLabel = accumulator.Source switch
+            {
+                StatusAccumulatorSource.DamageTaken => "damage taken",
+                StatusAccumulatorSource.HealingTaken => "healing received",
+                _ => accumulator.Source.ToString()
+            };
+
+            string fromLabel = accumulator.From switch
+            {
+                StatusAccumulatorContributor.CasterOnly => "from the caster only",
+                StatusAccumulatorContributor.Allies => "from allies",
+                StatusAccumulatorContributor.Any => "from any source",
+                _ => accumulator.From.ToString()
+            };
+
+            string dotLabel = accumulator.IncludeDotHot ? "including DoT/HoT" : "excluding DoT/HoT";
+            string amountLabel = accumulator.Amount switch
+            {
+                StatusAccumulatorAmount.PostMitigation => "post-mitigation values",
+                _ => accumulator.Amount.ToString()
+            };
+
+            string schoolLabel = accumulator.Source == StatusAccumulatorSource.DamageTaken && accumulator.DamageSchool.HasValue
+                ? $" ({accumulator.DamageSchool.Value} only)"
+                : string.Empty;
+
+            return $"Status {statusLabel} accumulates {sourceLabel}{schoolLabel} {fromLabel}, {dotLabel} ({amountLabel}) into '{accumulator.VariableKey}'.";
         }
         private static List<string> GatherStatusSkillIds(EffectDefinition effect, IReadOnlyList<string> explicitSkillIds)
         {

--- a/Assets/Scripts/TGD.Combat/EffectRuntimeType.cs
+++ b/Assets/Scripts/TGD.Combat/EffectRuntimeType.cs
@@ -386,6 +386,17 @@ namespace TGD.Combat
         public float Probability { get; set; }
         public EffectCondition Condition { get; set; }
         public EffectInterpretationResult InstantResult { get; set; }
+        public StatusAccumulatorPreview Accumulator { get; set; }
+    }
+
+    public class StatusAccumulatorPreview
+    {
+        public StatusAccumulatorSource Source { get; set; }
+        public StatusAccumulatorContributor From { get; set; }
+        public StatusAccumulatorAmount Amount { get; set; }
+        public bool IncludeDotHot { get; set; }
+        public DamageSchool? DamageSchool { get; set; }
+        public string VariableKey { get; set; }
     }
     public class StatusModificationPreview
     {

--- a/Assets/Scripts/TGD.Data/SkillDefinition.cs
+++ b/Assets/Scripts/TGD.Data/SkillDefinition.cs
@@ -71,6 +71,62 @@ namespace TGD.Data
         public bool secondRequireLineOfSight = true;
         public string secondSkillID;
     }
+
+    public enum StatusAccumulatorSource
+    {
+        DamageTaken,
+        HealingTaken
+    }
+
+    public enum StatusAccumulatorContributor
+    {
+        CasterOnly,
+        Allies,
+        Any
+    }
+
+    public enum StatusAccumulatorAmount
+    {
+        PostMitigation
+    }
+
+    [System.Serializable]
+    public class StatusAccumulatorSettings
+    {
+        public const string DamageVariableKey = "damage_accu";
+        public const string HealVariableKey = "heal_accu";
+
+        public bool enabled = false;
+        public StatusAccumulatorSource source = StatusAccumulatorSource.DamageTaken;
+        public StatusAccumulatorContributor from = StatusAccumulatorContributor.Allies;
+        public StatusAccumulatorAmount amount = StatusAccumulatorAmount.PostMitigation;
+        public bool includeDotHot = true;
+        public DamageSchool damageSchool = DamageSchool.Physical;
+
+        public string GetVariableKey()
+        {
+            return GetVariableKey(source);
+        }
+
+        public static string GetVariableKey(StatusAccumulatorSource accumulatorSource)
+        {
+            return accumulatorSource == StatusAccumulatorSource.DamageTaken
+                ? DamageVariableKey
+                : HealVariableKey;
+        }
+    }
+
+    [System.Serializable]
+    public class StatusSkillMetadata
+    {
+        public StatusAccumulatorSettings accumulatorSettings = new StatusAccumulatorSettings();
+
+        public void EnsureInitialized()
+        {
+            if (accumulatorSettings == null)
+                accumulatorSettings = new StatusAccumulatorSettings();
+        }
+    }
     [System.Serializable]
     public class SkillDurationSettings
     {
@@ -172,10 +228,15 @@ namespace TGD.Data
         [Range(1, 4)]
         public int skillLevel = 1; // 仅标记“当前等级”；真正的每级数值在 EffectDefinition 中 perLevel 填写
         public SkillDurationSettings skillDuration = new SkillDurationSettings();
+        public StatusSkillMetadata statusMetadata = new StatusSkillMetadata();
         private void OnValidate()
         {
             if (skillDuration == null)
                 skillDuration = new SkillDurationSettings();
+            if (statusMetadata == null)
+                statusMetadata = new StatusSkillMetadata();
+            else
+                statusMetadata.EnsureInitialized();
             if (string.IsNullOrWhiteSpace(skillTag))
                 skillTag = "none";
             if (multiTargetCount < 1)

--- a/Assets/Scripts/TGD.Editor/SkillDefinitionEditor.cs
+++ b/Assets/Scripts/TGD.Editor/SkillDefinitionEditor.cs
@@ -13,6 +13,10 @@ namespace TGD.Editor
         private SerializedProperty skillColorProp;
         private SerializedProperty skillLevelProp;
         private SerializedProperty skillDurationProp;
+        private SerializedProperty statusMetadataProp;
+
+        private bool showStatusMetadataFoldout = true;
+        private bool showStatusAccumulatorFoldout = true;
 
 
         private static readonly SkillColor[] kLeveledColors = new[]
@@ -31,6 +35,7 @@ namespace TGD.Editor
             skillColorProp = serializedObject.FindProperty("skillColor");
             skillLevelProp = serializedObject.FindProperty("skillLevel");
             skillDurationProp = serializedObject.FindProperty("skillDuration");
+            statusMetadataProp = serializedObject.FindProperty("statusMetadata");
         }
 
         public override void OnInspectorGUI()
@@ -169,6 +174,12 @@ namespace TGD.Editor
                     MessageType.Info);
 
                 // 其他依然可见：冷却、替换、范围等
+            }
+
+
+            if (skillType == SkillType.State)
+            {
+                DrawStatusMetadataSection();
             }
 
 
@@ -340,6 +351,102 @@ namespace TGD.Editor
                 effectsProp.InsertArrayElementAtIndex(effectsProp.arraySize);
 
             serializedObject.ApplyModifiedProperties();
+        }
+
+        private void DrawStatusMetadataSection()
+        {
+            EditorGUILayout.Space();
+            if (statusMetadataProp == null)
+            {
+                EditorGUILayout.HelpBox("'statusMetadata' property not found on SkillDefinition.", MessageType.Warning);
+                return;
+            }
+
+            showStatusMetadataFoldout = EditorGUILayout.Foldout(showStatusMetadataFoldout, "Status Metadata", true);
+            if (!showStatusMetadataFoldout)
+                return;
+
+            EditorGUI.indentLevel++;
+            var accumulatorProp = statusMetadataProp.FindPropertyRelative("accumulatorSettings");
+            DrawStatusAccumulatorSettings(accumulatorProp);
+            EditorGUI.indentLevel--;
+        }
+
+        private void DrawStatusAccumulatorSettings(SerializedProperty accumulatorProp)
+        {
+            if (accumulatorProp == null)
+            {
+                EditorGUILayout.HelpBox("'accumulatorSettings' property not found on status metadata.", MessageType.Warning);
+                return;
+            }
+
+            showStatusAccumulatorFoldout = EditorGUILayout.Foldout(showStatusAccumulatorFoldout, "Status Accumulator Settings", true);
+            if (!showStatusAccumulatorFoldout)
+                return;
+
+            EditorGUI.indentLevel++;
+            var enabledProp = accumulatorProp.FindPropertyRelative("enabled");
+            if (enabledProp == null)
+            {
+                EditorGUILayout.HelpBox("'enabled' property not found on status accumulator settings.", MessageType.Warning);
+                EditorGUI.indentLevel--;
+                return;
+            }
+
+            EditorGUILayout.PropertyField(enabledProp, new GUIContent("Enabled"));
+            if (enabledProp.boolValue)
+            {
+                EditorGUI.indentLevel++;
+                var sourceProp = accumulatorProp.FindPropertyRelative("source");
+                StatusAccumulatorSource sourceValue = StatusAccumulatorSource.DamageTaken;
+                if (sourceProp != null)
+                {
+                    EditorGUILayout.PropertyField(sourceProp, new GUIContent("Source"));
+                    sourceValue = (StatusAccumulatorSource)sourceProp.enumValueIndex;
+                }
+                else
+                {
+                    EditorGUILayout.HelpBox("'source' property not found on status accumulator settings.", MessageType.Warning);
+                }
+
+                var fromProp = accumulatorProp.FindPropertyRelative("from");
+                if (fromProp != null)
+                    EditorGUILayout.PropertyField(fromProp, new GUIContent("From"));
+                else
+                    EditorGUILayout.HelpBox("'from' property not found on status accumulator settings.", MessageType.Warning);
+
+                var amountProp = accumulatorProp.FindPropertyRelative("amount");
+                if (amountProp != null)
+                    EditorGUILayout.PropertyField(amountProp, new GUIContent("Amount"));
+                else
+                    EditorGUILayout.HelpBox("'amount' property not found on status accumulator settings.", MessageType.Warning);
+
+                var includeProp = accumulatorProp.FindPropertyRelative("includeDotHot");
+                if (includeProp != null)
+                    EditorGUILayout.PropertyField(includeProp, new GUIContent("Include DoT/HoT"));
+                else
+                    EditorGUILayout.HelpBox("'includeDotHot' property not found on status accumulator settings.", MessageType.Warning);
+
+                if (sourceValue == StatusAccumulatorSource.DamageTaken)
+                {
+                    var schoolProp = accumulatorProp.FindPropertyRelative("damageSchool");
+                    if (schoolProp != null)
+                        EditorGUILayout.PropertyField(schoolProp, new GUIContent("Damage School"));
+                    else
+                        EditorGUILayout.HelpBox("'damageSchool' property not found on status accumulator settings.", MessageType.Warning);
+                }
+
+                string variableKey = StatusAccumulatorSettings.GetVariableKey(sourceValue);
+                EditorGUILayout.HelpBox($"Accumulated value is stored in custom variable '{variableKey}'.", MessageType.Info);
+
+                EditorGUI.indentLevel--;
+            }
+            else
+            {
+                EditorGUILayout.HelpBox("Accumulator disabled. No values will be tracked for this status.", MessageType.None);
+            }
+
+            EditorGUI.indentLevel--;
         }
 
         private static bool DrawUseConditionClause(SerializedProperty condElem, bool secondary, SerializedProperty list = null, int index = -1)


### PR DESCRIPTION
## Summary
- add status accumulator metadata to skill definitions so status skills can track incoming damage or healing
- extend the skill inspector with a foldout to configure the accumulator settings for state-type skills
- surface accumulator data in the effect interpreter/runtime previews so logs mention the tracked values

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d170683438832484e6ff040b5a8b27