### PR TITLE
Add invert logic for effect trigger conditions

### DIFF
--- a/Assets/Scripts/TGD.Combat/EffectInterpreter.cs
+++ b/Assets/Scripts/TGD.Combat/EffectInterpreter.cs
@@ -507,7 +507,8 @@ namespace TGD.Combat
                     CanCrit = effect.canCrit,
                     Probability = probability,
                     Expression = expression,
-                    Condition = effect.condition
+                    Condition = effect.condition,
+                    ConditionNegated = effect.conditionNegate
                 };
 
                 PopulateDamagePreview(preview, effect, context, target);
@@ -551,7 +552,8 @@ namespace TGD.Combat
                     CanCrit = effect.canCrit,
                     Probability = probability,
                     Expression = expression,
-                    Condition = effect.condition
+                    Condition = effect.condition,
+                    ConditionNegated = effect.conditionNegate
                 });
                 totalHeal += amount;
                 result.AddLog($"Heal {DescribeUnit(target)} for {amount:0.##} ({probability:0.##}% chance).");
@@ -593,6 +595,7 @@ namespace TGD.Combat
                                 Probability = probability,
                                 Expression = expression,
                                 Condition = effect.condition,
+                                ConditionNegated = effect.conditionNegate,
                                 FillToMax = fillToMax,
                                 ModifyType = ResourceModifyType.Gain,
                                 AffectsMax = false,
@@ -623,6 +626,7 @@ namespace TGD.Combat
                                 Probability = probability,
                                 Expression = expression,
                                 Condition = effect.condition,
+                                ConditionNegated = effect.conditionNegate,
                                 FillToMax = false,
                                 ModifyType = ResourceModifyType.ConvertMax,
                                 AffectsMax = true,
@@ -646,6 +650,7 @@ namespace TGD.Combat
                                 Probability = probability,
                                 Expression = string.Empty,
                                 Condition = effect.condition,
+                                ConditionNegated = effect.conditionNegate,
                                 FillToMax = false,
                                 ModifyType = modifyType,
                                 AffectsMax = false,
@@ -674,7 +679,8 @@ namespace TGD.Combat
                 Operation = effect.scalingOperation,
                 Target = effect.target,
                 Probability = probability,
-                Condition = effect.condition
+                Condition = effect.condition,
+                ConditionNegated = effect.conditionNegate
             });
             string opLabel = effect.scalingOperation.ToString();
             string valueLabel = string.IsNullOrWhiteSpace(effect.scalingValuePerResource)
@@ -717,7 +723,8 @@ namespace TGD.Combat
                 MaxStacks = effect.maxStacks,
                 Target = effect.target,
                 Probability = probability,
-                Condition = effect.condition
+                Condition = effect.condition,
+                ConditionNegated = effect.conditionNegate
             };
 
             SkillDefinition statusSkill = null;
@@ -872,6 +879,7 @@ namespace TGD.Combat
                 MaxStacks = effect.statusModifyMaxStacks,
                 Probability = probability,
                 Condition = effect.condition,
+                ConditionNegated = effect.conditionNegate,
                 TransferFlags = effect.statusTransferFlags,
                 ClampToNewMax = effect.statusTransferClampToNewMax
             };
@@ -974,6 +982,7 @@ namespace TGD.Combat
                 CostResource = effect.modifyCostResource,
                 Probability = probability,
                 Condition = effect.condition,
+                ConditionNegated = effect.conditionNegate,
                 LimitEnabled = limitEnabled,
                 LimitExpression = limitEnabled ? effect.modifyLimitExpression : string.Empty,
                 LimitValue = limitEnabled ? resolvedLimit : 0f
@@ -1160,7 +1169,8 @@ namespace TGD.Combat
                 NewSkillID = effect.replaceSkillID,
                 InheritCooldown = effect.inheritReplacedCooldown,
                 Probability = probability,
-                Condition = effect.condition
+                Condition = effect.condition,
+                ConditionNegated = effect.conditionNegate
             });
 
             result.AddLog($"Replace skill '{targetSkill}' with '{effect.replaceSkillID}' (inherit cooldown: {effect.inheritReplacedCooldown}).");
@@ -1186,7 +1196,8 @@ namespace TGD.Combat
                 StopAdjacentToTarget = effect.moveStopAdjacentToTarget,
                 Target = effect.target,
                 Probability = probability,
-                Condition = effect.condition
+                Condition = effect.condition,
+                ConditionNegated = effect.conditionNegate
             };
 
             result.Moves.Add(preview);
@@ -1261,6 +1272,7 @@ namespace TGD.Combat
                 Duration = duration,
                 Probability = probability,
                 Condition = effect.condition,
+                ConditionNegated = effect.conditionNegate,
                 OnEnterCondition = effect.auraOnEnter,
                 OnExitCondition = effect.auraOnExit,
                 HeartbeatSeconds = effect.auraHeartSeconds
@@ -1313,6 +1325,7 @@ namespace TGD.Combat
                 Target = effect.target,
                 Probability = probability,
                 Condition = effect.condition,
+                ConditionNegated = effect.conditionNegate,
                 Duration = duration,
                 StackCount = stacks
             };
@@ -1473,7 +1486,8 @@ namespace TGD.Combat
                     StatusType = status.statusType,
                     Probability = probability,
                     Duration = duration,
-                    Condition = effect.condition
+                    Condition = effect.condition,
+                    ConditionNegated = effect.conditionNegate
                 };
 
                 switch (status.statusType)
@@ -1573,7 +1587,8 @@ namespace TGD.Combat
                 TargetTag = tagFilter,
                 ActionTypeOverride = effect.actionTypeOverride,
                 Probability = probability,
-                Condition = effect.condition
+                Condition = effect.condition,
+                ConditionNegated = effect.conditionNegate
             };
             result.ActionModifications.Add(preview);
 
@@ -1627,7 +1642,8 @@ namespace TGD.Combat
                 UseFilter = useFilter,
                 Filter = effect.damageSchoolFilter,
                 Probability = probability,
-                Condition = effect.condition
+                Condition = effect.condition,
+                ConditionNegated = effect.conditionNegate
             };
 
             result.DamageSchoolModifications.Add(preview);
@@ -1663,6 +1679,7 @@ namespace TGD.Combat
                 Target = effect.target,
                 Probability = probability,
                 Condition = effect.condition,
+                ConditionNegated = effect.conditionNegate,
                 ImmunityScope = effect.immunityScope
             };
 
@@ -1691,7 +1708,8 @@ namespace TGD.Combat
                 BreakDuration = settings.postureBreakDurationTurns,
                 BreakSkipsTurn = settings.postureBreakSkipsTurn,
                 Probability = probability,
-                Condition = effect.condition
+                Condition = effect.condition,
+                ConditionNegated = effect.conditionNegate
             });
 
             result.AddLog("Mastery posture engine configured.");
@@ -1735,7 +1753,8 @@ namespace TGD.Combat
                 Seconds = seconds,
                 Turns = turns,
                 Probability = probability,
-                Condition = effect.condition
+                Condition = effect.condition,
+                ConditionNegated = effect.conditionNegate
             });
 
             string scopeDescription = scope switch
@@ -1778,7 +1797,8 @@ namespace TGD.Combat
             {
                 RollCount = rollCount,
                 AllowDuplicates = allowDuplicates,
-                Condition = effect.condition
+                Condition = effect.condition,
+                ConditionNegated = effect.conditionNegate
             };
 
             int optionIndex = 0;
@@ -1834,7 +1854,8 @@ namespace TGD.Combat
                 CountExpression = expression,
                 ResourceType = effect.repeatResourceType,
                 ConsumeResource = effect.repeatConsumeResource,
-                Condition = effect.condition
+                Condition = effect.condition,
+                ConditionNegated = effect.conditionNegate
             };
 
             if (effect.repeatEffects != null && effect.repeatEffects.Count > 0 && count > 0)
@@ -1873,6 +1894,7 @@ namespace TGD.Combat
             {
                 Mode = effect.probabilityModifierMode,
                 Condition = effect.condition,
+                ConditionNegated = effect.conditionNegate,
                 Target = effect.target
             };
 
@@ -1905,6 +1927,7 @@ namespace TGD.Combat
                 Target = effect.target,
                 Probability = probability,
                 Condition = effect.condition,
+                ConditionNegated = effect.conditionNegate,
                 SupportsStacks = effect.dotHotShowStacks,
                 MaxStacks = effect.dotHotShowStacks ? effect.dotHotMaxStacks : 1
             };
@@ -1985,49 +2008,82 @@ namespace TGD.Combat
         }
         private static bool CheckCondition(EffectDefinition effect, EffectContext context)
         {
+            bool result = true;
             switch (effect.condition)
             {
                 case EffectCondition.None:
-                    return true;
+                    result = true;
+                    break;
                 case EffectCondition.AfterAttack:
-                    return context.ConditionAfterAttack && MatchesConditionTarget(effect.conditionTarget, context);
+                    result = context.ConditionAfterAttack && MatchesConditionTarget(effect.conditionTarget, context);
+                    break;
                 case EffectCondition.OnPerformAttack:
-                    return context.ConditionOnPerformAttack && MatchesConditionTarget(effect.conditionTarget, context);
+                    result = context.ConditionOnPerformAttack && MatchesConditionTarget(effect.conditionTarget, context);
+                    break;
                 case EffectCondition.OnPerformHeal:
-                    return context.ConditionOnPerformHeal && MatchesConditionTarget(effect.conditionTarget, context);
+                    result = context.ConditionOnPerformHeal && MatchesConditionTarget(effect.conditionTarget, context);
+                    break;
                 case EffectCondition.OnCriticalHit:
-                    return context.ConditionOnCrit;
+                    result = context.ConditionOnCrit;
+                    break;
                 case EffectCondition.OnCooldownEnd:
-                    return context.ConditionOnCooldownEnd;
+                    result = context.ConditionOnCooldownEnd;
+                    break;
                 case EffectCondition.AfterSkillUse:
                     if (!context.ConditionAfterSkillUse)
-                        return false;
+                    {
+                        result = false;
+                        break;
+                    }
+
                     string requiredSkill = effect.conditionSkillUseID;
-                    if (string.IsNullOrWhiteSpace(requiredSkill) || string.Equals(requiredSkill, "any", StringComparison.OrdinalIgnoreCase))
-                        return true;
+                    if (string.IsNullOrWhiteSpace(requiredSkill) ||
+                        string.Equals(requiredSkill, "any", StringComparison.OrdinalIgnoreCase))
+                    {
+                        result = true;
+                        break;
+                    }
+
                     string lastSkill = context.LastSkillUsedID;
-                    return !string.IsNullOrWhiteSpace(lastSkill) &&
-                           string.Equals(requiredSkill, lastSkill, StringComparison.OrdinalIgnoreCase);
+                    result = !string.IsNullOrWhiteSpace(lastSkill) &&
+                             string.Equals(requiredSkill, lastSkill, StringComparison.OrdinalIgnoreCase);
+                    break;
                 case EffectCondition.SkillStateActive:
                     if (!context.ConditionSkillStateActive)
-                        return false;
+                    {
+                        result = false;
+                        break;
+                    }
 
                     string requiredState = effect.conditionSkillStateID;
                     if (string.IsNullOrWhiteSpace(requiredState))
-                        return true;
+                    {
+                        result = true;
+                        break;
+                    }
 
                     int stateStacks = context.GetSkillStateStacks(requiredState);
                     if (stateStacks <= 0)
-                        return false;
+                    {
+                        result = false;
+                        break;
+                    }
 
                     if (effect.conditionSkillStateCheckStacks)
-                        return EvaluateComparison(stateStacks, effect.conditionSkillStateStacks, effect.conditionSkillStateStackCompare);
+                    {
+                        result = EvaluateComparison(stateStacks, effect.conditionSkillStateStacks, effect.conditionSkillStateStackCompare);
+                        break;
+                    }
 
-                    return true;
+                    result = true;
+                    break;
                 case EffectCondition.OnDotHotActive:
                     context.ConditionDotStacks = 0f;
                     if (context.ActiveDotHotStatuses == null || context.ActiveDotHotStatuses.Count == 0)
-                        return false;
+                    {
+                        result = false;
+                        break;
+                    }
 
                     TargetType dotTarget = effect.conditionDotTarget;
                     var skillList = effect.conditionDotSkillIDs;
@@ -2048,7 +2104,8 @@ namespace TGD.Combat
                         {
                             foreach (var id in skillList)
                             {
-                                if (!string.IsNullOrWhiteSpace(id) && string.Equals(id, status.SkillID, StringComparison.OrdinalIgnoreCase))
+                                if (!string.IsNullOrWhiteSpace(id) &&
+                                    string.Equals(id, status.SkillID, StringComparison.OrdinalIgnoreCase))
                                 {
                                     skillMatch = true;
                                     break;
@@ -2066,36 +2123,59 @@ namespace TGD.Combat
                     }
 
                     if (matchedEntries == 0)
-                        return false;
+                    {
+                        result = false;
+                        break;
+                    }
 
                     context.ConditionDotStacks = effect.conditionDotUseStacks ? Mathf.Max(0, totalStacks) : matchedEntries;
-                    return true;
+                    result = true;
+                    break;
                 case EffectCondition.OnNextSkillSpendResource:
                     if (!context.ConditionOnResourceSpend)
-                        return false;
+                    {
+                        result = false;
+                        break;
+                    }
+
                     float spent = context.GetResourceSpent(effect.conditionResourceType);
                     if (spent < effect.conditionMinAmount)
-                        return false;
+                    {
+                        result = false;
+                        break;
+                    }
+
                     context.LastResourceSpendType = effect.conditionResourceType;
                     context.LastResourceSpendAmount = spent;
-                    return true;
+                    result = true;
+                    break;
                 case EffectCondition.OnEffectEnd:
-                    return context.ConditionOnEffectEnd;
+                    result = context.ConditionOnEffectEnd;
+                    break;
                 case EffectCondition.OnDamageTaken:
-                    return context.ConditionOnDamageTaken;
+                    result = context.ConditionOnDamageTaken;
+                    break;
                 case EffectCondition.OnTurnBeginSelf:
-                    return context.ConditionOnTurnBeginSelf && MatchesConditionTarget(effect.conditionTarget, context);
+                    result = context.ConditionOnTurnBeginSelf && MatchesConditionTarget(effect.conditionTarget, context);
+                    break;
                 case EffectCondition.OnTurnBeginEnemy:
-                    return context.ConditionOnTurnBeginEnemy && MatchesConditionTarget(effect.conditionTarget, context);
+                    result = context.ConditionOnTurnBeginEnemy && MatchesConditionTarget(effect.conditionTarget, context);
+                    break;
                 case EffectCondition.OnTurnEndSelf:
-                    return context.ConditionOnTurnEndSelf && MatchesConditionTarget(effect.conditionTarget, context);
+                    result = context.ConditionOnTurnEndSelf && MatchesConditionTarget(effect.conditionTarget, context);
+                    break;
                 case EffectCondition.OnTurnEndEnemy:
-                    return context.ConditionOnTurnEndEnemy && MatchesConditionTarget(effect.conditionTarget, context);
+                    result = context.ConditionOnTurnEndEnemy && MatchesConditionTarget(effect.conditionTarget, context);
+                    break;
                 case EffectCondition.LinkCancelled:
-                    return context.ConditionLinkCancelled && MatchesConditionTarget(effect.conditionTarget, context);
+                    result = context.ConditionLinkCancelled && MatchesConditionTarget(effect.conditionTarget, context);
+                    break;
                 default:
-                    return true;
+                    result = true;
+                    break;
             }
+
+            return effect.conditionNegate ? !result : result;
         }
 
         private static List<Unit> ResolveTargets(TargetType targetType, EffectContext context)

--- a/Assets/Scripts/TGD.Combat/EffectRuntimeType.cs
+++ b/Assets/Scripts/TGD.Combat/EffectRuntimeType.cs
@@ -338,6 +338,7 @@ namespace TGD.Combat
         public float Probability { get; set; }
         public string Expression { get; set; }
         public EffectCondition Condition { get; set; }
+        public bool ConditionNegated { get; set; }
         public ImmunityScope ImmunityScope { get; set; }
         public float ExpectedNormalDamage { get; set; }
         public float ExpectedCriticalDamage { get; set; }
@@ -358,6 +359,7 @@ namespace TGD.Combat
         public float Probability { get; set; }
         public string Expression { get; set; }
         public EffectCondition Condition { get; set; }
+        public bool ConditionNegated { get; set; }
     }
 
     public class ResourceChangePreview
@@ -368,6 +370,7 @@ namespace TGD.Combat
         public float Probability { get; set; }
         public string Expression { get; set; }
         public EffectCondition Condition { get; set; }
+        public bool ConditionNegated { get; set; }
         public bool FillToMax { get; set; }
         public ResourceModifyType ModifyType { get; set; }
         public bool AffectsMax { get; set; }
@@ -385,6 +388,7 @@ namespace TGD.Combat
         public TargetType Target { get; set; }
         public float Probability { get; set; }
         public EffectCondition Condition { get; set; }
+        public bool ConditionNegated { get; set; }
         public EffectInterpretationResult InstantResult { get; set; }
         public StatusAccumulatorPreview Accumulator { get; set; }
     }
@@ -410,6 +414,7 @@ namespace TGD.Combat
         public int MaxStacks { get; set; }
         public float Probability { get; set; }
         public EffectCondition Condition { get; set; }
+        public bool ConditionNegated { get; set; }
         public StatusTransferFlags TransferFlags { get; set; }
         public bool ClampToNewMax { get; set; } = true;
     }
@@ -461,6 +466,7 @@ namespace TGD.Combat
         public CostResourceType CostResource { get; set; }
         public float Probability { get; set; }
         public EffectCondition Condition { get; set; }
+        public bool ConditionNegated { get; set; }
         public bool LimitEnabled { get; set; }
         public string LimitExpression { get; set; }
         public float LimitValue { get; set; }
@@ -477,6 +483,7 @@ namespace TGD.Combat
         public bool InheritCooldown { get; set; }
         public float Probability { get; set; }
         public EffectCondition Condition { get; set; }
+        public bool ConditionNegated { get; set; }
     }
 
     public class ActionModificationPreview
@@ -490,6 +497,7 @@ namespace TGD.Combat
         public ActionType ActionTypeOverride { get; set; }
         public float Probability { get; set; }
         public EffectCondition Condition { get; set; }
+        public bool ConditionNegated { get; set; }
     }
 
     public class DamageSchoolModificationPreview
@@ -504,6 +512,7 @@ namespace TGD.Combat
         public string ValueExpression { get; set; }
         public float Probability { get; set; }
         public EffectCondition Condition { get; set; }
+        public bool ConditionNegated { get; set; }
     }
 
     public class CooldownModificationPreview
@@ -515,6 +524,7 @@ namespace TGD.Combat
         public int Turns {  get; set; }
         public float Probability { get; set; }
         public EffectCondition Condition { get; set; }
+        public bool ConditionNegated { get; set; }
     }
 
     public class AttributeModifierPreview
@@ -527,6 +537,7 @@ namespace TGD.Combat
         public TargetType Target { get; set; }
         public float Probability { get; set; }
         public EffectCondition Condition { get; set; }
+        public bool ConditionNegated { get; set; }
         public ImmunityScope ImmunityScope { get; set; }
     }
 
@@ -540,6 +551,7 @@ namespace TGD.Combat
         public TargetType Target { get; set; }
         public float Probability { get; set; }
         public EffectCondition Condition { get; set; }
+        public bool ConditionNegated { get; set; }
     }
 
     public class MovePreview
@@ -558,6 +570,7 @@ namespace TGD.Combat
         public TargetType Target { get; set; }
         public float Probability { get; set; }
         public EffectCondition Condition { get; set; }
+        public bool ConditionNegated { get; set; }
     }
 
     public class AuraPreview
@@ -573,6 +586,7 @@ namespace TGD.Combat
         public int Duration { get; set; }
         public float Probability { get; set; }
         public EffectCondition Condition { get; set; }
+        public bool ConditionNegated { get; set; }
         public EffectCondition OnEnterCondition { get; set; }
         public EffectCondition OnExitCondition { get; set; }
         public int HeartbeatSeconds { get; set; }
@@ -600,6 +614,7 @@ namespace TGD.Combat
         public TargetType Target { get; set; }
         public float Probability { get; set; }
         public EffectCondition Condition { get; set; }
+        public bool ConditionNegated { get; set; }
         public int Duration { get; set; }
         public int StackCount { get; set; }
         public string ValueExpression { get; set; }
@@ -627,6 +642,7 @@ namespace TGD.Combat
         public bool AllowDuplicates { get; set; }
         public List<RandomOutcomeOptionPreview> Options { get; } = new();
         public EffectCondition Condition { get; set; }
+        public bool ConditionNegated { get; set; }
     }
 
     public class RepeatEffectPreview
@@ -638,6 +654,7 @@ namespace TGD.Combat
         public ResourceType ResourceType { get; set; }
         public bool ConsumeResource { get; set; }
         public EffectCondition Condition { get; set; }
+        public bool ConditionNegated { get; set; }
         public EffectInterpretationResult Result { get; set; }
     }
 
@@ -645,6 +662,7 @@ namespace TGD.Combat
     {
         public ProbabilityModifierMode Mode { get; set; }
         public EffectCondition Condition { get; set; }
+        public bool ConditionNegated { get; set; }
         public TargetType Target { get; set; }
     }
 
@@ -660,6 +678,7 @@ namespace TGD.Combat
         public TargetType Target { get; set; }
         public float Probability { get; set; }
         public EffectCondition Condition { get; set; }
+        public bool ConditionNegated { get; set; }
         public EffectInterpretationResult AdditionalEffects { get; set; }
         public bool SupportsStacks { get; set; }
         public int MaxStacks { get; set; }
@@ -671,6 +690,7 @@ namespace TGD.Combat
         public float Probability { get; set; }
         public int Duration { get; set; }
         public EffectCondition Condition { get; set; }
+        public bool ConditionNegated { get; set; }
         public float Seconds { get; set; }
         public int SkippedTurns { get; set; }
         public float BaseTurnTimeRemaining { get; set; }
@@ -699,5 +719,6 @@ namespace TGD.Combat
         public bool BreakSkipsTurn { get; set; }
         public float Probability { get; set; }
         public EffectCondition Condition { get; set; }
+        public bool ConditionNegated { get; set; }
     }
 }

--- a/Assets/Scripts/TGD.Combat/Ops/EffectOperation.cs
+++ b/Assets/Scripts/TGD.Combat/Ops/EffectOperation.cs
@@ -31,6 +31,7 @@ namespace TGD.Combat
         public EffectOpType Type { get; }
         public float Probability { get; init; } = 100f;
         public EffectCondition Condition { get; init; } = EffectCondition.None;
+        public bool ConditionNegated { get; init; }
     }
 
     public sealed class DealDamageOp : EffectOp
@@ -214,7 +215,7 @@ namespace TGD.Combat
         {
         }
 
-        public Unit AnchorUnit { get; set; }    // ¡û ĞÂ×Ö¶Î
+        public Unit AnchorUnit { get; set; }    // Â¡Ã» ÃÃ‚Ã—Ã–Â¶Ã
 
         public TargetType Source { get; init; } = TargetType.Self;
         public AuraRangeMode RangeMode { get; init; } = AuraRangeMode.Within;

--- a/Assets/Scripts/TGD.Combat/Resolver/EffectResolver.cs
+++ b/Assets/Scripts/TGD.Combat/Resolver/EffectResolver.cs
@@ -56,6 +56,7 @@ namespace TGD.Combat
                     Expression = entry.Expression,
                     Probability = entry.Probability,
                     Condition = entry.Condition,
+                    ConditionNegated = entry.ConditionNegated,
                     ImmunityScope = entry.ImmunityScope,
                     ExpectedNormalDamage = entry.ExpectedNormalDamage,
                     ExpectedCriticalDamage = entry.ExpectedCriticalDamage,
@@ -87,7 +88,8 @@ namespace TGD.Combat
                     CanCrit = entry.CanCrit,
                     Expression = entry.Expression,
                     Probability = entry.Probability,
-                    Condition = entry.Condition
+                    Condition = entry.Condition,
+                    ConditionNegated = entry.ConditionNegated
                 });
             }
         }
@@ -112,7 +114,8 @@ namespace TGD.Combat
                     AffectsMax = entry.AffectsMax,
                     StateEnabled = entry.StateEnabled,
                     Probability = entry.Probability,
-                    Condition = entry.Condition
+                    Condition = entry.Condition,
+                    ConditionNegated = entry.ConditionNegated
                 });
             }
         }
@@ -156,6 +159,7 @@ namespace TGD.Combat
                     MaxStacks = entry.MaxStacks,
                     Probability = entry.Probability,
                     Condition = entry.Condition,
+                    ConditionNegated = entry.ConditionNegated,
                     Accumulator = accumulator,
                     InstantOperations = instantOps
                 };
@@ -198,7 +202,8 @@ namespace TGD.Combat
                     MaxStacks = entry.MaxStacks,
                     Replacement = replacement,
                     Probability = entry.Probability,
-                    Condition = entry.Condition
+                    Condition = entry.Condition,
+                    ConditionNegated = entry.ConditionNegated
                 };
 
                 operations.Add(op);
@@ -232,7 +237,8 @@ namespace TGD.Combat
                     SkillId = entry.SelfSkillID,
                     DeltaSeconds = ResolveCooldownSeconds(entry),
                     Probability = entry.Probability,
-                    Condition = entry.Condition
+                    Condition = entry.Condition,
+                    ConditionNegated = entry.ConditionNegated
                 });
             }
         }
@@ -272,7 +278,8 @@ namespace TGD.Combat
                     ExcludeTags = entry.ExcludeTags?.Where(NotNullOrWhiteSpace).ToArray() ?? Array.Empty<string>(),
                     SourceHandle = entry.SourceHandle,
                     Probability = entry.Probability,
-                    Condition = entry.Condition
+                    Condition = entry.Condition,
+                    ConditionNegated = entry.ConditionNegated
                 });
             }
         }
@@ -294,7 +301,8 @@ namespace TGD.Combat
                     NewSkillId = entry.NewSkillID,
                     InheritCooldown = entry.InheritCooldown,
                     Probability = entry.Probability,
-                    Condition = entry.Condition
+                    Condition = entry.Condition,
+                    ConditionNegated = entry.ConditionNegated
                 });
             }
         }
@@ -323,7 +331,8 @@ namespace TGD.Combat
                     StopAdjacentToTarget = entry.StopAdjacentToTarget,
                     TargetType = entry.Target,
                     Probability = entry.Probability,
-                    Condition = entry.Condition
+                    Condition = entry.Condition,
+                    ConditionNegated = entry.ConditionNegated
                 });
             }
         }
@@ -363,7 +372,8 @@ namespace TGD.Combat
                     OnExitCondition = entry.OnExitCondition,
                     AdditionalOperations = additionalOps,
                     Probability = entry.Probability,
-                    Condition = entry.Condition
+                    Condition = entry.Condition,
+                    ConditionNegated = entry.ConditionNegated
                 });
             }
         }
@@ -406,7 +416,8 @@ namespace TGD.Combat
                     ConsumeResource = repeat.ConsumeResource,
                     Operations = repeatOps,
                     Probability = 100f,
-                    Condition = repeat.Condition
+                    Condition = repeat.Condition,
+                    ConditionNegated = repeat.ConditionNegated
                 });
             }
 
@@ -447,7 +458,8 @@ namespace TGD.Combat
                     RepeatCount = random.RollCount,
                     AllowDuplicates = random.AllowDuplicates,
                     Probability = 100f,
-                    Condition = random.Condition
+                    Condition = random.Condition,
+                    ConditionNegated = random.ConditionNegated
                 });
             }
 
@@ -467,7 +479,8 @@ namespace TGD.Combat
                     Kind = ScheduleKind.DotHotAdditional,
                     Operations = nested,
                     Probability = dotHot.Probability,
-                    Condition = dotHot.Condition
+                    Condition = dotHot.Condition,
+                    ConditionNegated = dotHot.ConditionNegated
                 });
             }
         }

--- a/Assets/Scripts/TGD.Combat/System/AuraSystem.cs
+++ b/Assets/Scripts/TGD.Combat/System/AuraSystem.cs
@@ -131,6 +131,7 @@ namespace TGD.Combat
                 MaxStacks = op.MaxStacks,
                 Probability = op.Probability,
                 Condition = op.Condition,
+                ConditionNegated = op.ConditionNegated,
                 Accumulator = op.Accumulator,
                 InstantOperations = op.InstantOperations
             };
@@ -149,7 +150,8 @@ namespace TGD.Combat
                 MaxStacks = op.MaxStacks,
                 Replacement = op.Replacement,
                 Probability = op.Probability,
-                Condition = op.Condition
+                Condition = op.Condition,
+                ConditionNegated = op.ConditionNegated
             };
         }
     }

--- a/Assets/Scripts/TGD.Data/EffectDefinition.cs
+++ b/Assets/Scripts/TGD.Data/EffectDefinition.cs
@@ -357,6 +357,7 @@ namespace TGD.Data
         public string probability;     // 概率（字符串，允许 "p%"）
 
         public EffectCondition condition = EffectCondition.None;
+        public bool conditionNegate = false; // "!" logic: execute unless the condition is met
         public EffectFieldMask visibleFields =
     EffectFieldMask.Probability |
     EffectFieldMask.Duration |

--- a/Assets/Scripts/TGD.Editor/EffectDrawers/FieldVisibilityUI.cs
+++ b/Assets/Scripts/TGD.Editor/EffectDrawers/FieldVisibilityUI.cs
@@ -6,11 +6,11 @@ using TGD.Data;
 namespace TGD.Editor
 {
     /// <summary>
-    /// Í³Ò»µÄ¡°ÏÔÊ¾/Òş²Ø¿ª¹Ø¡±äÖÈ¾ÓëÎ»ÑÚÂë¶ÁĞ´¡£
+    /// ç»Ÿä¸€çš„â€œæ˜¾ç¤º/éšè—å¼€å…³â€æ¸²æŸ“ä¸ä½æ©ç è¯»å†™ã€‚
     /// </summary>
     public static class FieldVisibilityUI
     {
-        /// ¹´Ñ¡Ò»¸ö¿É¼ûĞÔ¿ª¹Ø£»·µ»Ø£ºµ±Ç°ÊÇ·ñÏÔÊ¾¸ÃÇø¿é
+        /// å‹¾é€‰ä¸€ä¸ªå¯è§æ€§å¼€å…³ï¼›è¿”å›ï¼šå½“å‰æ˜¯å¦æ˜¾ç¤ºè¯¥åŒºå—
         public static bool Toggle(SerializedProperty elem, EffectFieldMask flag, string label)
         {
             var maskProp = elem.FindPropertyRelative("visibleFields");
@@ -26,7 +26,7 @@ namespace TGD.Editor
             return newOn;
         }
 
-        /// ¶ÁÈ¡ÊÇ·ñ°üº¬Ä³ flag
+        /// è¯»å–æ˜¯å¦åŒ…å«æŸ flag
         public static bool Has(SerializedProperty elem, EffectFieldMask flag)
         {
             var maskProp = elem.FindPropertyRelative("visibleFields");
@@ -34,14 +34,22 @@ namespace TGD.Editor
             return (mask & flag) != 0;
         }
 
-        /// Êı×é³¤¶ÈĞ£Õı
+        /// æ•°ç»„é•¿åº¦æ ¡æ­£
         public static void EnsureSize(SerializedProperty arr, int n)
         {
             while (arr.arraySize < n) arr.InsertArrayElementAtIndex(arr.arraySize);
             while (arr.arraySize > n) arr.DeleteArrayElementAtIndex(arr.arraySize - 1);
         }
 
-        /// ¼æÈİ¾É×Ö¶ÎÃûµÄ»ñÈ¡£¨ÓÅÏÈÖ÷Ãû£¬´ÎÑ¡±ğÃû£©
+            var negateProp = elem.FindPropertyRelative("conditionNegate");
+            if (negateProp != null)
+            {
+                EditorGUILayout.PropertyField(
+                    negateProp,
+                    new GUIContent("Invert Condition (!)", "Enable to apply the effect unless the trigger condition is met."));
+            }
+
+        /// å…¼å®¹æ—§å­—æ®µåçš„è·å–ï¼ˆä¼˜å…ˆä¸»åï¼Œæ¬¡é€‰åˆ«åï¼‰
         public static SerializedProperty GetProp(SerializedProperty elem, string mainName, params string[] altNames)
         {
             var p = elem.FindPropertyRelative(mainName);

--- a/Assets/Scripts/TGD.Editor/EffectDrawers/NastedEffectDrawer.cs
+++ b/Assets/Scripts/TGD.Editor/EffectDrawers/NastedEffectDrawer.cs
@@ -124,6 +124,7 @@ namespace TGD.Editor
 
             SetBool(effectProp.FindPropertyRelative("perLevel"), false);
             SetBool(effectProp.FindPropertyRelative("perLevelDuration"), true);
+            SetBool(effectProp.FindPropertyRelative("conditionNegate"), false);
 
             SetBool(effectProp.FindPropertyRelative("repeatConsumeResource"), true);
 

--- a/Assets/Scripts/TGD.Editor/EffectSummaryUtility.cs
+++ b/Assets/Scripts/TGD.Editor/EffectSummaryUtility.cs
@@ -1159,9 +1159,15 @@ namespace TGD.Editor
             if (condition == EffectCondition.None)
                 return string.Empty;
 
+            bool invert = effectProp.FindPropertyRelative("conditionNegate")?.boolValue ?? false;
+
             var sb = new StringBuilder();
             sb.Append("Condition: ");
+            if (invert)
+                sb.Append('!');
             sb.Append(condition);
+            if (invert)
+                sb.Append(" (invert)");
 
             switch (condition)
             {

--- a/Assets/Scripts/TGD.Editor/SkillDefinitionEditor.cs
+++ b/Assets/Scripts/TGD.Editor/SkillDefinitionEditor.cs
@@ -296,6 +296,8 @@ namespace TGD.Editor
             EditorGUILayout.Space();
             EditorGUILayout.LabelField("Effects", EditorStyles.boldLabel);
 
+            EditorGUILayout.HelpBox("Trigger Conditions support "!" logic via the Invert Condition toggle.", MessageType.Info);
+
             if (effectsProp == null)
             {
                 EditorGUILayout.HelpBox("'effects' property not found on SkillDefinition.", MessageType.Error);


### PR DESCRIPTION
## Summary
- add a `conditionNegate` flag to effects and teach the interpreter/resolver/runtime types to propagate the inverted trigger condition through operations
- update editor utilities to expose the new Invert Condition toggle, reset it for nested effects, and reflect it in generated summaries
- document the new logic in the inspector to highlight the available "!" trigger behaviour

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d3ac20098883249d25f4a605bdaf8a