### PR TITLE
Implement turn manager, systems, and skill loading

### DIFF
--- a/Assets/Scripts/TGD.Combat/CombatLog.cs
+++ b/Assets/Scripts/TGD.Combat/CombatLog.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace TGD.Combat
+{
+    /// <summary>
+    /// In-memory combat logger that mirrors entries to the Unity console.
+    /// </summary>
+    [CreateAssetMenu(fileName = "CombatLog", menuName = "TGD/Combat Log", order = 0)]
+    public sealed class CombatLog : ScriptableObject, ICombatLogger
+    {
+        [SerializeField]
+        private List<string> entries = new();
+
+        public IReadOnlyList<string> Entries => entries;
+
+        public event Action<string> OnEntryAdded;
+
+        public void Clear()
+        {
+            entries.Clear();
+        }
+
+        public void Emit(LogOp op, RuntimeCtx ctx)
+        {
+            if (op == null || string.IsNullOrWhiteSpace(op.Message))
+                return;
+            Log(op.Message);
+        }
+
+        public void Log(string eventType, params object[] args)
+        {
+            if (string.IsNullOrWhiteSpace(eventType))
+                return;
+
+            string message = args == null || args.Length == 0
+                ? eventType
+                : $"{eventType}: {string.Join(", ", FormatArguments(args))}";
+
+            entries.Add(message);
+            Debug.Log(message);
+            OnEntryAdded?.Invoke(message);
+        }
+
+        private static IEnumerable<string> FormatArguments(IEnumerable<object> args)
+        {
+            foreach (var arg in args)
+            {
+                if (arg == null)
+                    continue;
+                switch (arg)
+                {
+                    case float f:
+                        yield return f.ToString("0.###");
+                        break;
+                    case double d:
+                        yield return d.ToString("0.###");
+                        break;
+                    default:
+                        yield return arg.ToString();
+                        break;
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/TGD.Combat/System/ConsoleCombatLogger.cs
+++ b/Assets/Scripts/TGD.Combat/System/ConsoleCombatLogger.cs
@@ -1,4 +1,5 @@
 using System;
+using System;
 using System.Linq;
 
 namespace TGD.Combat

--- a/Assets/Scripts/TGD.Combat/System/DamageSystem.cs
+++ b/Assets/Scripts/TGD.Combat/System/DamageSystem.cs
@@ -1,0 +1,175 @@
+using System;
+using UnityEngine;
+using TGD.Core;
+using TGD.Data;
+
+namespace TGD.Combat
+{
+    public sealed class DamageSystem : IDamageSystem
+    {
+        private readonly ICombatLogger _logger;
+        private readonly ICombatEventBus _bus;
+        private readonly ICombatTime _time;
+
+        public DamageSystem(ICombatLogger logger, ICombatEventBus bus, ICombatTime time)
+        {
+            _logger = logger;
+            _bus = bus;
+            _time = time;
+        }
+
+        public void Execute(DealDamageOp op, RuntimeCtx ctx)
+        {
+            if (op == null)
+                return;
+
+            var source = op.Source ?? ctx?.Caster;
+            var target = op.Target ?? ctx?.PrimaryTarget;
+            if (target?.Stats == null)
+                return;
+
+            var attackerStats = source?.Stats;
+            float baseDamage = Mathf.Max(0f, op.Amount);
+            bool isCritical = DetermineCritical(op, attackerStats);
+
+            var damageInput = new CombatFormula.DamageInput
+            {
+                SkillDamage = baseDamage,
+                IsCritical = isCritical,
+                PrimaryAttributeValue = ResolvePrimaryStat(attackerStats),
+                AdditionalDamageMultiplier = attackerStats?.DamageIncrease ?? 0f,
+                SituationalDamageMultiplier = attackerStats?.DamageIncreaseSecondary ?? 0f,
+                DamageReduction = target.Stats.DamageReduction,
+                ArmorMitigationMultiplier = ComputeArmorMitigation(attackerStats, target.Stats, op.School),
+                SkillThreatMultiplier = ctx?.Skill?.threat ?? 0f,
+                SkillShredMultiplier = ctx?.Skill?.shredMultiplier ?? 0f,
+                MasteryConversionRatio = ResolveMasteryRatio(source)
+            };
+
+            var result = CombatFormula.CalculateDamage(damageInput, attackerStats ?? new Stats());
+            float finalDamage = result.Damage;
+            finalDamage *= Mathf.Max(0.01f, target.Stats.DamageTakenMultiplier);
+
+            ApplyDamage(target, finalDamage);
+
+            _logger?.Log("DAMAGE", source?.UnitId ?? "SYSTEM", target.UnitId, finalDamage, op.School, isCritical ? "CRIT" : "NORMAL");
+            _bus?.EmitDamageResolved(source, target, finalDamage, false, op.School, _time?.Now ?? 0f);
+        }
+
+        public void Execute(HealOp op, RuntimeCtx ctx)
+        {
+            if (op == null)
+                return;
+
+            var source = op.Source ?? ctx?.Caster;
+            var target = op.Target ?? ctx?.PrimaryTarget;
+            if (target?.Stats == null)
+                return;
+
+            float baseHeal = Mathf.Max(0f, op.Amount);
+            bool isCritical = DetermineCritical(op, source?.Stats);
+            float multiplier = 1f + (source?.Stats?.HealIncrease ?? 0f);
+            if (isCritical)
+                multiplier *= 2f + (source?.Stats?.CritDamage ?? 0f) / 100f;
+
+            float healAmount = baseHeal * multiplier;
+            healAmount = Mathf.Max(0f, healAmount);
+
+            target.Stats.HP += Mathf.RoundToInt(healAmount);
+            target.Stats.Clamp();
+
+            _logger?.Log("HEAL", source?.UnitId ?? "SYSTEM", target.UnitId, healAmount, isCritical ? "CRIT" : "NORMAL");
+        }
+
+        private static void ApplyDamage(Unit target, float amount)
+        {
+            if (target?.Stats == null)
+                return;
+
+            int damage = Mathf.RoundToInt(amount);
+            if (damage <= 0)
+                return;
+
+            if (target.Stats.Shield > 0)
+            {
+                int absorbed = Mathf.Min(target.Stats.Shield, damage);
+                target.Stats.Shield -= absorbed;
+                damage -= absorbed;
+            }
+
+            if (damage <= 0)
+                return;
+
+            target.Stats.HP -= damage;
+            if (target.Stats.HP < 0)
+                target.Stats.HP = 0;
+        }
+
+        private static bool DetermineCritical(DealDamageOp op, Stats attacker)
+        {
+            if (!op.CanCrit || attacker == null)
+                return false;
+
+            float critChance = Mathf.Clamp01(attacker.Crit);
+            return UnityEngine.Random.value < critChance;
+        }
+
+        private static bool DetermineCritical(HealOp op, Stats caster)
+        {
+            if (!op.CanCrit || caster == null)
+                return false;
+
+            float critChance = Mathf.Clamp01(caster.Crit);
+            return UnityEngine.Random.value < critChance;
+        }
+
+        private static float ResolvePrimaryStat(Stats stats)
+        {
+            if (stats == null)
+                return 0f;
+            return Mathf.Max(stats.Strength, stats.Agility, stats.Attack, stats.SpellPower);
+        }
+
+        private static float ResolveMasteryRatio(Unit unit)
+        {
+            if (unit?.Skills == null)
+                return 1f;
+
+            foreach (var skill in unit.Skills)
+            {
+                if (skill == null)
+                    continue;
+                if (skill.skillType == SkillType.Mastery && skill.masteryStatConversionRatio > 0f)
+                    return skill.masteryStatConversionRatio;
+            }
+
+            return 1f;
+        }
+
+        private static float ComputeArmorMitigation(Stats attacker, Stats defender, DamageSchool school)
+        {
+            if (defender == null)
+                return 1f;
+
+            int armor = Mathf.Max(0, defender.Armor);
+            if (attacker != null)
+                armor = Mathf.Max(0, armor - attacker.ArmorPenetration);
+
+            const float armorScaling = 120f;
+            float reduction = armor / (armor + armorScaling);
+            reduction = Mathf.Clamp01(reduction);
+
+            switch (school)
+            {
+                case DamageSchool.Magical:
+                case DamageSchool.Fire:
+                case DamageSchool.Frost:
+                    // Magical schools rely a bit more on mitigation.
+                    reduction *= 0.9f;
+                    break;
+            }
+
+            return 1f - reduction;
+        }
+    }
+}

--- a/Assets/Scripts/TGD.Combat/System/ResourceSystem.cs
+++ b/Assets/Scripts/TGD.Combat/System/ResourceSystem.cs
@@ -1,0 +1,97 @@
+using UnityEngine;
+using TGD.Data;
+
+namespace TGD.Combat
+{
+    public sealed class ResourceSystem : IResourceSystem
+    {
+        private readonly ICombatLogger _logger;
+
+        public ResourceSystem(ICombatLogger logger)
+        {
+            _logger = logger;
+        }
+
+        public void Execute(ModifyResourceOp op, RuntimeCtx ctx)
+        {
+            if (op == null)
+                return;
+
+            var target = op.Target ?? ctx?.Caster;
+            if (target?.Stats == null)
+                return;
+
+            float amount = op.Amount;
+
+            switch (op.Resource)
+            {
+                case ResourceType.HP:
+                    ModifyHp(target, amount, op.ModifyType);
+                    break;
+                case ResourceType.Energy:
+                    ModifyEnergy(target, amount, op.ModifyType);
+                    break;
+                case ResourceType.posture:
+                    ModifyPosture(target, amount, op.ModifyType);
+                    break;
+            }
+        }
+
+        private void ModifyHp(Unit unit, float amount, ResourceModifyType type)
+        {
+            int delta = Mathf.RoundToInt(amount);
+            if (type == ResourceModifyType.Gain)
+            {
+                unit.Stats.HP += delta;
+                if (unit.Stats.HP > unit.Stats.MaxHP)
+                    unit.Stats.HP = unit.Stats.MaxHP;
+            }
+            else if (type == ResourceModifyType.ConvertMax)
+            {
+                unit.Stats.MaxHP += delta;
+                if (unit.Stats.MaxHP < 1)
+                    unit.Stats.MaxHP = 1;
+                if (unit.Stats.HP > unit.Stats.MaxHP)
+                    unit.Stats.HP = unit.Stats.MaxHP;
+            }
+
+            _logger?.Log("RESOURCE_HP", unit.UnitId, unit.Stats.HP, unit.Stats.MaxHP);
+        }
+
+        private void ModifyEnergy(Unit unit, float amount, ResourceModifyType type)
+        {
+            int delta = Mathf.RoundToInt(amount);
+            switch (type)
+            {
+                case ResourceModifyType.Gain:
+                    unit.Stats.Energy = Mathf.Clamp(unit.Stats.Energy + delta, 0, unit.Stats.MaxEnergy);
+                    break;
+                case ResourceModifyType.ConvertMax:
+                    unit.Stats.MaxEnergy = Mathf.Max(0, unit.Stats.MaxEnergy + delta);
+                    unit.Stats.Energy = Mathf.Clamp(unit.Stats.Energy, 0, unit.Stats.MaxEnergy);
+                    break;
+                default:
+                    unit.Stats.Energy = Mathf.Clamp(unit.Stats.Energy + delta, 0, unit.Stats.MaxEnergy);
+                    break;
+            }
+
+            _logger?.Log("RESOURCE_ENERGY", unit.UnitId, unit.Stats.Energy, unit.Stats.MaxEnergy);
+        }
+
+        private void ModifyPosture(Unit unit, float amount, ResourceModifyType type)
+        {
+            int delta = Mathf.RoundToInt(amount);
+            if (type == ResourceModifyType.Gain)
+            {
+                unit.Stats.Posture = Mathf.Clamp(unit.Stats.Posture + delta, 0, unit.Stats.MaxPosture);
+            }
+            else if (type == ResourceModifyType.ConvertMax)
+            {
+                unit.Stats.MaxPosture = Mathf.Max(0, unit.Stats.MaxPosture + delta);
+                unit.Stats.Posture = Mathf.Clamp(unit.Stats.Posture, 0, unit.Stats.MaxPosture);
+            }
+
+            _logger?.Log("RESOURCE_POSTURE", unit.UnitId, unit.Stats.Posture, unit.Stats.MaxPosture);
+        }
+    }
+}

--- a/Assets/Scripts/TGD.Combat/TurnManager.cs
+++ b/Assets/Scripts/TGD.Combat/TurnManager.cs
@@ -1,0 +1,390 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using TGD.Core;
+using TGD.Data;
+
+namespace TGD.Combat
+{
+    public sealed class TurnManager
+    {
+        private readonly IList<Unit> _players;
+        private readonly IList<Unit> _enemies;
+        private readonly ICombatEventBus _eventBus;
+        private readonly ICombatLogger _logger;
+        private readonly ICombatTime _time;
+        private readonly ISkillResolver _skillResolver;
+        private readonly IDamageSystem _damageSystem;
+        private readonly IResourceSystem _resourceSystem;
+        private readonly IStatusSystem _statusSystem;
+        private readonly ICooldownSystem _cooldownSystem;
+        private readonly ISkillModSystem _skillModSystem;
+        private readonly IMovementSystem _movementSystem;
+        private readonly IAuraSystem _auraSystem;
+        private readonly IScheduler _scheduler;
+        private readonly RuntimeCtx _runtime;
+        private readonly List<Unit> _allyBuffer = new();
+        private readonly List<Unit> _enemyBuffer = new();
+        private readonly Dictionary<Unit, Dictionary<string, int>> _dotHotRounds = new();
+
+        private bool _turnShouldEnd;
+        private int _roundIndex;
+
+        public TurnManager(IList<Unit> players, IList<Unit> enemies,
+            ICombatEventBus eventBus, ICombatLogger logger, ICombatTime time,
+            ISkillResolver skillResolver, IDamageSystem damageSystem,
+            IResourceSystem resourceSystem, IStatusSystem statusSystem,
+            ICooldownSystem cooldownSystem, ISkillModSystem skillModSystem,
+            IMovementSystem movementSystem, IAuraSystem auraSystem,
+            IScheduler scheduler)
+        {
+            _players = players ?? Array.Empty<Unit>();
+            _enemies = enemies ?? Array.Empty<Unit>();
+            _eventBus = eventBus;
+            _logger = logger;
+            _time = time;
+            _skillResolver = skillResolver;
+            _damageSystem = damageSystem;
+            _resourceSystem = resourceSystem;
+            _statusSystem = statusSystem;
+            _cooldownSystem = cooldownSystem;
+            _skillModSystem = skillModSystem;
+            _movementSystem = movementSystem;
+            _auraSystem = auraSystem;
+            _scheduler = scheduler;
+
+            _runtime = new RuntimeCtx
+            {
+                Logger = logger,
+                EventBus = eventBus,
+                Time = time,
+                SkillResolver = skillResolver,
+                DamageSystem = damageSystem,
+                ResourceSystem = resourceSystem,
+                StatusSystem = statusSystem,
+                CooldownSystem = cooldownSystem,
+                SkillModSystem = skillModSystem,
+                MovementSystem = movementSystem,
+                AuraSystem = auraSystem,
+                Scheduler = scheduler
+            };
+        }
+
+        public Unit ActiveUnit { get; private set; }
+
+        public IEnumerator RunLoop()
+        {
+            while (true)
+            {
+                foreach (var player in _players)
+                {
+                    if (player == null)
+                        continue;
+                    yield return RunTurn(player, isPlayer: true);
+                }
+
+                foreach (var enemy in _enemies)
+                {
+                    if (enemy == null)
+                        continue;
+                    yield return RunTurn(enemy, isPlayer: false);
+                }
+
+                _roundIndex++;
+                yield return null;
+            }
+        }
+
+        public void EndTurnEarly()
+        {
+            _turnShouldEnd = true;
+        }
+
+        public bool ExecuteSkill(Unit caster, SkillDefinition skill, Unit primaryTarget, Unit secondaryTarget = null)
+        {
+            if (caster == null || skill == null)
+                return false;
+            if (ActiveUnit != caster)
+                return false;
+            if (caster.IsOnCooldown(skill))
+            {
+                _logger?.Log("SKILL_COOLDOWN", caster.UnitId, skill.skillID);
+                return false;
+            }
+
+            if (!HasResources(caster, skill))
+            {
+                _logger?.Log("SKILL_RESOURCE_FAIL", caster.UnitId, skill.skillID);
+                return false;
+            }
+
+            int timeCost = Mathf.Max(0, skill.timeCostSeconds);
+            if (caster.RemainingTime < timeCost)
+            {
+                _logger?.Log("SKILL_TIME_FAIL", caster.UnitId, skill.skillID, caster.RemainingTime, timeCost);
+                return false;
+            }
+
+            SpendResources(caster, skill);
+
+            PrepareRuntime(caster, primaryTarget, secondaryTarget, skill);
+            _logger?.Log("SKILL_CAST", caster.UnitId, skill.skillID, primaryTarget?.UnitId ?? "none");
+
+            ActionSystem.Execute(caster, skill, _runtime);
+            caster.SetCooldown(skill);
+
+            caster.SpendTime(timeCost);
+            _time?.Advance(timeCost);
+
+            if (caster.RemainingTime <= 0)
+                _turnShouldEnd = true;
+
+            return true;
+        }
+
+        private IEnumerator RunTurn(Unit unit, bool isPlayer)
+        {
+            ActiveUnit = unit;
+            _turnShouldEnd = false;
+
+            unit.StartTurn();
+            _eventBus?.EmitTurnBegin(unit);
+            _logger?.Log("TURN_BEGIN", unit.UnitId, _roundIndex, unit.RemainingTime);
+
+            ProcessDotHot(unit);
+
+            if (isPlayer)
+            {
+                while (!_turnShouldEnd)
+                {
+                    if (unit.RemainingTime <= 0)
+                        break;
+                    yield return null;
+                }
+            }
+            else
+            {
+                float wait = 1f;
+                while (!_turnShouldEnd && wait > 0f)
+                {
+                    wait -= Time.deltaTime;
+                    yield return null;
+                }
+                _turnShouldEnd = true;
+            }
+
+            FinishTurn(unit, isPlayer);
+            ActiveUnit = null;
+        }
+
+        private void FinishTurn(Unit unit, bool isPlayer)
+        {
+            unit.EndTurn();
+            _eventBus?.EmitTurnEnd(unit);
+            _logger?.Log("TURN_END", unit.UnitId);
+
+            _cooldownSystem?.TickEndOfTurn();
+
+            if (!isPlayer)
+                ApplyEnemyRegeneration(unit);
+        }
+
+        private void ApplyEnemyRegeneration(Unit unit)
+        {
+            if (unit?.Stats == null)
+                return;
+
+            if (unit.Stats.HealthRegenPerTurn > 0)
+            {
+                unit.Stats.HP = Mathf.Min(unit.Stats.MaxHP, unit.Stats.HP + unit.Stats.HealthRegenPerTurn);
+            }
+
+            if (unit.Stats.ArmorRegenPerTurn > 0)
+            {
+                unit.Stats.Armor = Mathf.Max(0, unit.Stats.Armor + unit.Stats.ArmorRegenPerTurn);
+            }
+
+            unit.Stats.Clamp();
+            _logger?.Log("ENEMY_REGEN", unit.UnitId, unit.Stats.HP, unit.Stats.Armor);
+        }
+
+        private void PrepareRuntime(Unit caster, Unit primaryTarget, Unit secondaryTarget, SkillDefinition skill)
+        {
+            _runtime.Caster = caster;
+            _runtime.PrimaryTarget = primaryTarget;
+            _runtime.SecondaryTarget = secondaryTarget;
+            _runtime.Skill = skill;
+
+            _allyBuffer.Clear();
+            _enemyBuffer.Clear();
+
+            CollectUnits(_players, caster.TeamId, _allyBuffer, includeTeam: true);
+            CollectUnits(_enemies, caster.TeamId, _allyBuffer, includeTeam: true);
+            CollectUnits(_players, caster.TeamId, _enemyBuffer, includeTeam: false);
+            CollectUnits(_enemies, caster.TeamId, _enemyBuffer, includeTeam: false);
+
+            _runtime.Allies = _allyBuffer.ToArray();
+            _runtime.Enemies = _enemyBuffer.ToArray();
+        }
+
+        private static void CollectUnits(IEnumerable<Unit> source, int teamId, ICollection<Unit> destination, bool includeTeam)
+        {
+            if (source == null || destination == null)
+                return;
+
+            foreach (var unit in source)
+            {
+                if (unit == null)
+                    continue;
+                if (includeTeam && unit.TeamId == teamId)
+                    destination.Add(unit);
+                else if (!includeTeam && unit.TeamId != teamId)
+                    destination.Add(unit);
+            }
+        }
+
+        private bool HasResources(Unit caster, SkillDefinition skill)
+        {
+            if (skill.costs == null || skill.costs.Count == 0)
+                return true;
+
+            foreach (var cost in skill.costs)
+            {
+                if (cost == null)
+                    continue;
+                float amount = cost.ResolveAmount();
+                switch (cost.resourceType)
+                {
+                    case CostResourceType.Energy:
+                        if (caster.Stats.Energy < amount)
+                            return false;
+                        break;
+                    case CostResourceType.HP:
+                        if (caster.Stats.HP < amount)
+                            return false;
+                        break;
+                }
+            }
+
+            return true;
+        }
+
+        private void SpendResources(Unit caster, SkillDefinition skill)
+        {
+            if (skill.costs == null)
+                return;
+
+            foreach (var cost in skill.costs)
+            {
+                if (cost == null)
+                    continue;
+                int amount = Mathf.RoundToInt(cost.ResolveAmount());
+                switch (cost.resourceType)
+                {
+                    case CostResourceType.Energy:
+                        caster.Stats.Energy = Mathf.Max(0, caster.Stats.Energy - amount);
+                        break;
+                    case CostResourceType.HP:
+                        caster.Stats.HP = Mathf.Max(1, caster.Stats.HP - amount);
+                        break;
+                }
+            }
+
+            caster.Stats.Clamp();
+        }
+
+        private void ProcessDotHot(Unit unit)
+        {
+            if (unit?.Statuses == null || unit.Statuses.Count == 0)
+                return;
+
+            if (!_dotHotRounds.TryGetValue(unit, out var tracker))
+            {
+                tracker = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+                _dotHotRounds[unit] = tracker;
+            }
+
+            var stillActive = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var status in unit.Statuses)
+            {
+                if (status == null)
+                    continue;
+
+                var statusSkill = status.StatusSkill ?? _skillResolver?.ResolveById(status.StatusSkillId);
+                if (statusSkill == null || statusSkill.effects == null)
+                    continue;
+
+                foreach (var effect in statusSkill.effects)
+                {
+                    if (effect == null)
+                        continue;
+
+                    if (effect.dotHotOperation != DotHotOperation.TriggerDots &&
+                        effect.dotHotOperation != DotHotOperation.TriggerHots)
+                        continue;
+
+                    stillActive.Add(status.StatusSkillId);
+                    if (!ShouldTriggerDotHot(tracker, status.StatusSkillId))
+                        continue;
+
+                    ApplyDotHot(status, effect);
+                    tracker[status.StatusSkillId] = _roundIndex;
+                }
+            }
+
+            var toRemove = tracker.Keys.Where(id => !stillActive.Contains(id)).ToList();
+            foreach (var key in toRemove)
+                tracker.Remove(key);
+        }
+
+        private bool ShouldTriggerDotHot(Dictionary<string, int> tracker, string statusId)
+        {
+            if (string.IsNullOrWhiteSpace(statusId))
+                return false;
+            return !tracker.TryGetValue(statusId, out var lastRound) || lastRound < _roundIndex;
+        }
+
+        private void ApplyDotHot(StatusInstance status, EffectDefinition effect)
+        {
+            var target = status.Target;
+            if (target == null)
+                return;
+
+            var source = status.Source ?? target;
+            PrepareRuntime(source, target, null, status.StatusSkill ?? _skillResolver?.ResolveById(status.StatusSkillId));
+
+            float baseAmount = effect.value;
+            if (status.StackCount > 1)
+                baseAmount *= status.StackCount;
+
+            EffectOp op;
+            if (effect.dotHotOperation == DotHotOperation.TriggerHots)
+            {
+                op = new HealOp
+                {
+                    Source = source,
+                    Target = target,
+                    Amount = baseAmount,
+                    CanCrit = effect.canCrit
+                };
+            }
+            else
+            {
+                op = new DealDamageOp
+                {
+                    Source = source,
+                    Target = target,
+                    Amount = baseAmount,
+                    CanCrit = effect.canCrit,
+                    School = effect.damageSchool
+                };
+            }
+
+            EffectOpRunner.Run(new[] { op }, _runtime);
+            _logger?.Log(effect.dotHotOperation == DotHotOperation.TriggerHots ? "HOT_TICK" : "DOT_TICK",
+                target.UnitId, baseAmount, status.StatusSkillId);
+        }
+    }
+}

--- a/Assets/Scripts/TGD.Combat/Unit.cs
+++ b/Assets/Scripts/TGD.Combat/Unit.cs
@@ -7,9 +7,11 @@ using TGD.Data;
 
 namespace TGD.Combat
 {
+    [Serializable]
     public class Unit
     {
         public string UnitId;
+        public string ClassId;
         public int TeamId;
         public Stats Stats = new Stats();
         public HexCoord Position;
@@ -50,8 +52,35 @@ namespace TGD.Combat
 
         public void EndTurn()
         {
-            foreach (var key in _cdSeconds.Keys.ToList())
-                _cdSeconds[key] = Math.Max(0, _cdSeconds[key] - CombatClock.BaseTurnSeconds);
+            RemainingTime = 0;
+            PrepaidTime = 0;
+        }
+
+        public void SpendTime(int seconds)
+        {
+            if (seconds <= 0)
+                return;
+
+            RemainingTime -= seconds;
+            if (RemainingTime < 0)
+            {
+                PrepaidTime += -RemainingTime;
+                RemainingTime = 0;
+            }
+        }
+
+        public void RefundTime(int seconds)
+        {
+            if (seconds <= 0)
+                return;
+
+            RemainingTime += seconds;
+            if (PrepaidTime > 0)
+            {
+                int refund = Math.Min(PrepaidTime, RemainingTime);
+                PrepaidTime -= refund;
+                RemainingTime -= refund;
+            }
         }
 
         public bool IsOnCooldown(SkillDefinition skill)

--- a/Assets/Scripts/TGD.Core/Stats.cs
+++ b/Assets/Scripts/TGD.Core/Stats.cs
@@ -5,6 +5,7 @@ namespace TGD.Core
     /// <summary>
     /// Aggregates the base stats for a combat unit.
     /// </summary>
+    [Serializable]
     public class Stats
     {
         public int Level;
@@ -16,6 +17,7 @@ namespace TGD.Core
 
         // Base offensive power.
         public int Attack;
+        public int SpellPower;
 
         // Class resources.
         public int Energy;
@@ -31,9 +33,13 @@ namespace TGD.Core
         // stacks additively only when coming from the same skill ID).
         public float DamageIncrease;
         public float HealIncrease;
+        public float DamageIncreaseSecondary;
+        public float DamageReduction;
+        public float DamageTakenMultiplier = 1f;
 
         // Defensive layer.
         public int Armor;
+        public int ArmorPenetration;
 
         // Ratings converted to normalized ratios. Example: 0.325f => 32.5% crit chance.
         public float Crit;
@@ -49,6 +55,11 @@ namespace TGD.Core
         // Bonus threat / shred multipliers (0.15f => +15%).
         public float Threat;
         public float Shred;
+
+        // Combat utility stats to ease playtest iteration.
+        public int HealthRegenPerTurn;
+        public int ArmorRegenPerTurn;
+        public int Shield;
 
         public void Clamp()
         {
@@ -69,7 +80,10 @@ namespace TGD.Core
             Crit = RoundToThreeDecimals(Crit);
             Mastery = RoundToThreeDecimals(Mastery);
             DamageIncrease = RoundToThreeDecimals(DamageIncrease);
+            DamageIncreaseSecondary = RoundToThreeDecimals(DamageIncreaseSecondary);
             HealIncrease = RoundToThreeDecimals(HealIncrease);
+            DamageReduction = RoundToThreeDecimals(DamageReduction);
+            DamageTakenMultiplier = RoundToThreeDecimals(DamageTakenMultiplier);
             Threat = RoundToThreeDecimals(Threat);
             Shred = RoundToThreeDecimals(Shred);
         }

--- a/Assets/Scripts/TGD.Data/SkillDatabase.cs
+++ b/Assets/Scripts/TGD.Data/SkillDatabase.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace TGD.Data
+{
+    public static class SkillDatabase
+    {
+        private static readonly Dictionary<string, SkillDefinition> SkillsById = new(StringComparer.OrdinalIgnoreCase);
+        private static readonly Dictionary<string, List<SkillDefinition>> SkillsByClass = new(StringComparer.OrdinalIgnoreCase);
+        private static bool _initialized;
+
+        public static void EnsureLoaded(string resourcePath = "SkillDataJason")
+        {
+            if (_initialized)
+                return;
+
+            SkillsById.Clear();
+            SkillsByClass.Clear();
+
+            var assets = Resources.LoadAll<TextAsset>(resourcePath);
+            foreach (var asset in assets)
+            {
+                if (asset == null || string.IsNullOrWhiteSpace(asset.text))
+                    continue;
+
+                try
+                {
+                    var skill = ScriptableObject.CreateInstance<SkillDefinition>();
+                    JsonUtility.FromJsonOverwrite(asset.text, skill);
+                    PostProcess(skill);
+                    Register(skill);
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogError($"Failed to parse skill JSON '{asset.name}': {ex.Message}");
+                }
+            }
+
+            _initialized = true;
+        }
+
+        public static SkillDefinition GetSkillById(string skillId)
+        {
+            EnsureLoaded();
+            if (string.IsNullOrWhiteSpace(skillId))
+                return null;
+            return SkillsById.TryGetValue(skillId, out var value) ? value : null;
+        }
+
+        public static IReadOnlyList<SkillDefinition> GetSkillsForClass(string classId)
+        {
+            EnsureLoaded();
+            if (string.IsNullOrWhiteSpace(classId))
+                return Array.Empty<SkillDefinition>();
+            return SkillsByClass.TryGetValue(classId, out var list) ? list : Array.Empty<SkillDefinition>();
+        }
+
+        public static IReadOnlyList<SkillDefinition> GetAllSkills()
+        {
+            EnsureLoaded();
+            return new List<SkillDefinition>(SkillsById.Values);
+        }
+
+        private static void Register(SkillDefinition skill)
+        {
+            if (skill == null || string.IsNullOrWhiteSpace(skill.skillID))
+                return;
+
+            SkillsById[skill.skillID] = skill;
+            if (!SkillsByClass.TryGetValue(skill.classID ?? string.Empty, out var list))
+            {
+                list = new List<SkillDefinition>();
+                SkillsByClass[skill.classID ?? string.Empty] = list;
+            }
+
+            if (!list.Contains(skill))
+                list.Add(skill);
+        }
+
+        private static void PostProcess(SkillDefinition skill)
+        {
+            if (skill == null)
+                return;
+            if (skill.skillDuration == null)
+                skill.skillDuration = new SkillDurationSettings();
+            if (skill.statusMetadata == null)
+                skill.statusMetadata = new StatusSkillMetadata();
+            skill.statusMetadata.EnsureInitialized();
+            if (!string.IsNullOrWhiteSpace(skill.skillID))
+                skill.name = skill.skillID;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a serializable stats and unit configuration that exposes extended combat attributes and turn accounting helpers
- add a new turn manager and combat log that orchestrate player/enemy turns, cooldown ticks, DoT/HoT handling and regeneration
- wire the combat loop to the new systems, including skill loading from JSON, and provide damage/resource runtime systems for effect execution

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68d44646cde0832486657da1764dc223