### PR TITLE
Integrate ScriptableObject skills and grid targeting

### DIFF
--- a/Assets/Scripts/TGD.Combat/Core/ClassResourceCatalog.cs
+++ b/Assets/Scripts/TGD.Combat/Core/ClassResourceCatalog.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using TGD.Core;
+using TGD.Data;
+using UnityEngine;
+
+namespace TGD.Combat
+{
+    /// <summary>
+    /// Describes the default class resource profiles for each class identifier.
+    /// </summary>
+    public static class ClassResourceCatalog
+    {
+        public readonly struct ClassResourceProfile
+        {
+            public ClassResourceProfile(CostResourceType resourceType, int defaultMax, int defaultStart)
+            {
+                if (resourceType == CostResourceType.Custom)
+                    throw new ArgumentException("Custom resource cannot be part of class defaults.", nameof(resourceType));
+
+                ResourceType = resourceType;
+                DefaultMax = Mathf.Max(0, defaultMax);
+                DefaultStart = Mathf.Clamp(defaultStart, 0, DefaultMax);
+            }
+
+            public CostResourceType ResourceType { get; }
+            public int DefaultMax { get; }
+            public int DefaultStart { get; }
+        }
+
+        private static readonly Dictionary<string, ClassResourceProfile[]> ProfilesByClass =
+            new(StringComparer.OrdinalIgnoreCase)
+            {
+                { "CL001", new[] { new ClassResourceProfile(CostResourceType.Discipline, 5, 0) } },
+                { "CL002", new[] { new ClassResourceProfile(CostResourceType.Discipline, 5, 0) } },
+                { "CL003", new[] { new ClassResourceProfile(CostResourceType.Discipline, 5, 0) } },
+
+                { "CL011", new[] { new ClassResourceProfile(CostResourceType.Iron, 5, 0) } },
+                { "CL012", new[] { new ClassResourceProfile(CostResourceType.Iron, 5, 0) } },
+                { "CL013", new[]
+                    {
+                        new ClassResourceProfile(CostResourceType.Iron, 5, 0),
+                        new ClassResourceProfile(CostResourceType.posture, 4, 0)
+                    }
+                },
+
+                { "CL021", new[] { new ClassResourceProfile(CostResourceType.Rage, 100, 0) } },
+                { "CL022", new[] { new ClassResourceProfile(CostResourceType.Versatility, 5, 0) } },
+
+                { "CL031", new[] { new ClassResourceProfile(CostResourceType.Gunpowder, 5, 0) } },
+                { "CL032", new[] { new ClassResourceProfile(CostResourceType.point, 3, 0) } },
+                { "CL041", new[] { new ClassResourceProfile(CostResourceType.combo, 5, 0) } },
+                { "CL042", new[] { new ClassResourceProfile(CostResourceType.point, 3, 0) } },
+
+                { "CL051", new[] { new ClassResourceProfile(CostResourceType.punch, 5, 0) } },
+                { "CL053", new[] { new ClassResourceProfile(CostResourceType.qi, 4, 0) } },
+                { "CL071", new[] { new ClassResourceProfile(CostResourceType.vision, 5, 0) } },
+            };
+
+        private static readonly ClassResourceProfile[] EmptyProfiles = Array.Empty<ClassResourceProfile>();
+
+        public static IReadOnlyList<ClassResourceProfile> GetProfiles(string classId)
+        {
+            if (string.IsNullOrWhiteSpace(classId))
+                return EmptyProfiles;
+
+            return ProfilesByClass.TryGetValue(classId, out var list) ? list : EmptyProfiles;
+        }
+
+        public static IReadOnlyList<CostResourceType> GetResourceTypes(string classId)
+        {
+            if (string.IsNullOrWhiteSpace(classId))
+                return Array.Empty<CostResourceType>();
+
+            if (!ProfilesByClass.TryGetValue(classId, out var profiles) || profiles == null || profiles.Length == 0)
+                return Array.Empty<CostResourceType>();
+
+            var list = new List<CostResourceType>(profiles.Length);
+            foreach (var profile in profiles)
+                list.Add(profile.ResourceType);
+            return list;
+        }
+
+        public static void ApplyDefaults(Stats stats, string classId, bool overwriteExisting = false)
+        {
+            if (stats == null)
+                return;
+
+            foreach (var profile in GetProfiles(classId))
+                ResourceUtility.ApplyDefaults(stats, profile, overwriteExisting);
+        }
+
+        public static void ApplyDefaults(Unit unit, bool overwriteExisting = false)
+        {
+            if (unit == null)
+                return;
+
+            ApplyDefaults(unit.Stats, unit.ClassId, overwriteExisting);
+        }
+    }
+}

--- a/Assets/Scripts/TGD.Combat/Core/ResourceUtility.cs
+++ b/Assets/Scripts/TGD.Combat/Core/ResourceUtility.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Generic;
+using TGD.Core;
+using TGD.Data;
+using UnityEngine;
+
+namespace TGD.Combat
+{
+    public readonly struct ResourceAccessor
+    {
+        private readonly Func<int> _getCurrent;
+        private readonly Action<int> _setCurrent;
+        private readonly Func<int> _getMax;
+        private readonly Action<int> _setMax;
+
+        public ResourceAccessor(Func<int> getCurrent, Action<int> setCurrent, Func<int> getMax, Action<int> setMax)
+        {
+            _getCurrent = getCurrent;
+            _setCurrent = setCurrent;
+            _getMax = getMax;
+            _setMax = setMax;
+        }
+
+        public bool IsValid => _getCurrent != null && _setCurrent != null && _getMax != null && _setMax != null;
+
+        public int Current
+        {
+            get => _getCurrent != null ? _getCurrent() : 0;
+            set => _setCurrent?.Invoke(value);
+        }
+
+        public int Max
+        {
+            get => _getMax != null ? _getMax() : 0;
+            set => _setMax?.Invoke(value);
+        }
+    }
+
+    public static class ResourceUtility
+    {
+        public static bool TryGetAccessor(Stats stats, ResourceType type, out ResourceAccessor accessor)
+        {
+            accessor = default;
+            if (stats == null)
+                return false;
+
+            switch (type)
+            {
+                case ResourceType.HP:
+                    accessor = new ResourceAccessor(() => stats.HP, v => stats.HP = v, () => stats.MaxHP, v => stats.MaxHP = v);
+                    return true;
+                case ResourceType.Energy:
+                    accessor = new ResourceAccessor(() => stats.Energy, v => stats.Energy = v, () => stats.MaxEnergy, v => stats.MaxEnergy = v);
+                    return true;
+                case ResourceType.Discipline:
+                    accessor = new ResourceAccessor(() => stats.Discipline, v => stats.Discipline = v, () => stats.MaxDiscipline, v => stats.MaxDiscipline = v);
+                    return true;
+                case ResourceType.Iron:
+                    accessor = new ResourceAccessor(() => stats.Iron, v => stats.Iron = v, () => stats.MaxIron, v => stats.MaxIron = v);
+                    return true;
+                case ResourceType.Rage:
+                    accessor = new ResourceAccessor(() => stats.Rage, v => stats.Rage = v, () => stats.MaxRage, v => stats.MaxRage = v);
+                    return true;
+                case ResourceType.Versatility:
+                    accessor = new ResourceAccessor(() => stats.Versatility, v => stats.Versatility = v, () => stats.MaxVersatility, v => stats.MaxVersatility = v);
+                    return true;
+                case ResourceType.Gunpowder:
+                    accessor = new ResourceAccessor(() => stats.Gunpowder, v => stats.Gunpowder = v, () => stats.MaxGunpowder, v => stats.MaxGunpowder = v);
+                    return true;
+                case ResourceType.point:
+                    accessor = new ResourceAccessor(() => stats.Point, v => stats.Point = v, () => stats.MaxPoint, v => stats.MaxPoint = v);
+                    return true;
+                case ResourceType.combo:
+                    accessor = new ResourceAccessor(() => stats.Combo, v => stats.Combo = v, () => stats.MaxCombo, v => stats.MaxCombo = v);
+                    return true;
+                case ResourceType.punch:
+                    accessor = new ResourceAccessor(() => stats.Punch, v => stats.Punch = v, () => stats.MaxPunch, v => stats.MaxPunch = v);
+                    return true;
+                case ResourceType.qi:
+                    accessor = new ResourceAccessor(() => stats.Qi, v => stats.Qi = v, () => stats.MaxQi, v => stats.MaxQi = v);
+                    return true;
+                case ResourceType.vision:
+                    accessor = new ResourceAccessor(() => stats.Vision, v => stats.Vision = v, () => stats.MaxVision, v => stats.MaxVision = v);
+                    return true;
+                case ResourceType.posture:
+                    accessor = new ResourceAccessor(() => stats.Posture, v => stats.Posture = v, () => stats.MaxPosture, v => stats.MaxPosture = v);
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        public static bool TryGetAccessor(Stats stats, CostResourceType type, out ResourceAccessor accessor)
+        {
+            accessor = default;
+            if (type == CostResourceType.Custom)
+                return false;
+
+            if (!Enum.TryParse(type.ToString(), true, out ResourceType resourceType))
+                return false;
+
+            return TryGetAccessor(stats, resourceType, out accessor);
+        }
+
+        public static IEnumerable<ResourceType> EnumerateAvailable(Unit unit)
+        {
+            if (unit?.Stats == null)
+                yield break;
+
+            foreach (ResourceType type in Enum.GetValues(typeof(ResourceType)))
+            {
+                if (TryGetAccessor(unit.Stats, type, out var accessor) && accessor.IsValid)
+                    yield return type;
+            }
+        }
+
+        public static void ApplyDefaults(Stats stats, ClassResourceCatalog.ClassResourceProfile profile, bool overwriteExisting)
+        {
+            if (stats == null)
+                return;
+
+            if (!TryGetAccessor(stats, profile.ResourceType, out var accessor) || !accessor.IsValid)
+                return;
+
+            int current = accessor.Current;
+            int max = accessor.Max;
+
+            if (overwriteExisting || max <= 0)
+                accessor.Max = Mathf.Max(profile.DefaultMax, max);
+
+            max = accessor.Max;
+
+            if (overwriteExisting || current <= 0)
+                accessor.Current = Mathf.Clamp(profile.DefaultStart, 0, max);
+        }
+
+        public static void WriteResource(Unit unit, ResourceType type, int current, int max)
+        {
+            if (unit?.Stats == null)
+                return;
+
+            if (!TryGetAccessor(unit.Stats, type, out var accessor) || !accessor.IsValid)
+                return;
+
+            accessor.Max = Mathf.Max(0, max);
+            accessor.Current = Mathf.Clamp(current, 0, accessor.Max);
+        }
+    }
+}

--- a/Assets/Scripts/TGD.Combat/Runtime/CombatLoop.cs
+++ b/Assets/Scripts/TGD.Combat/Runtime/CombatLoop.cs
@@ -122,6 +122,7 @@ namespace TGD.Combat
                 if (unit == null) continue;
 
                 unit.Stats ??= new Stats();
+                ClassResourceCatalog.ApplyDefaults(unit);
                 unit.Stats.Clamp();
 
                 unit.Skills ??= new List<SkillDefinition>();
@@ -137,15 +138,21 @@ namespace TGD.Combat
         }
 
         // —— UI按钮可调用 —— //
+        public bool ExecuteSkill(Unit caster, SkillDefinition skill, Unit primaryTarget)
+        {
+            if (_turnManager == null || caster == null || skill == null)
+                return false;
+
+            return _turnManager.ExecuteSkill(caster, skill, primaryTarget);
+        }
+
         public bool ExecuteSkill(Unit caster, string skillId, Unit primaryTarget)
         {
             if (_turnManager == null || caster == null || string.IsNullOrWhiteSpace(skillId))
                 return false;
 
             var skill = _skillResolver.ResolveById(skillId);
-            if (skill == null) return false;
-
-            return _turnManager.ExecuteSkill(caster, skill, primaryTarget);
+            return ExecuteSkill(caster, skill, primaryTarget);
         }
 
         public void EndActiveTurn() => _turnManager?.EndTurnEarly();

--- a/Assets/Scripts/TGD.Combat/Uti/EffectRuntimeType.cs
+++ b/Assets/Scripts/TGD.Combat/Uti/EffectRuntimeType.cs
@@ -67,12 +67,14 @@ namespace TGD.Combat
             if (caster != null)
             {
                 Allies.Add(caster);
-                ResourceValues[ResourceType.HP] = caster.Stats.HP;
-                ResourceValues[ResourceType.Energy] = caster.Stats.Energy;
-                ResourceValues[ResourceType.posture] = caster.Stats.Posture;
-                ResourceMaxValues[ResourceType.HP] = caster.Stats.MaxHP;
-                ResourceMaxValues[ResourceType.Energy] = caster.Stats.MaxEnergy;
-                ResourceMaxValues[ResourceType.posture] = caster.Stats.MaxPosture;
+                foreach (var type in ResourceUtility.EnumerateAvailable(caster))
+                {
+                    if (ResourceUtility.TryGetAccessor(caster.Stats, type, out var accessor) && accessor.IsValid)
+                    {
+                        ResourceValues[type] = accessor.Current;
+                        ResourceMaxValues[type] = accessor.Max;
+                    }
+                }
             }
         }
 

--- a/Assets/Scripts/TGD.Core/Stats.cs
+++ b/Assets/Scripts/TGD.Core/Stats.cs
@@ -24,7 +24,37 @@ namespace TGD.Core
         public int MaxEnergy;
         public int EnergyRegenPer2s;
 
-        // Posture (class exclusive resource).
+        public int Discipline;
+        public int MaxDiscipline;
+
+        public int Iron;
+        public int MaxIron;
+
+        public int Rage;
+        public int MaxRage;
+
+        public int Versatility;
+        public int MaxVersatility;
+
+        public int Gunpowder;
+        public int MaxGunpowder;
+
+        public int Point;
+        public int MaxPoint;
+
+        public int Combo;
+        public int MaxCombo;
+
+        public int Punch;
+        public int MaxPunch;
+
+        public int Qi;
+        public int MaxQi;
+
+        public int Vision;
+        public int MaxVision;
+
+        // Posture (class exclusive resource / mastery extension).
         public int Posture;
         public int MaxPosture;
         public int Strength;
@@ -66,8 +96,18 @@ namespace TGD.Core
             if (HP > MaxHP) HP = MaxHP;
             if (HP < 0) HP = 0;
 
-            if (Energy > MaxEnergy) Energy = MaxEnergy;
-            if (Energy < 0) Energy = 0;
+            ClampResource(ref Energy, ref MaxEnergy);
+            ClampResource(ref Discipline, ref MaxDiscipline);
+            ClampResource(ref Iron, ref MaxIron);
+            ClampResource(ref Rage, ref MaxRage);
+            ClampResource(ref Versatility, ref MaxVersatility);
+            ClampResource(ref Gunpowder, ref MaxGunpowder);
+            ClampResource(ref Point, ref MaxPoint);
+            ClampResource(ref Combo, ref MaxCombo);
+            ClampResource(ref Punch, ref MaxPunch);
+            ClampResource(ref Qi, ref MaxQi);
+            ClampResource(ref Vision, ref MaxVision);
+            ClampResource(ref Posture, ref MaxPosture);
 
             NormalizeDecimalStats();
         }
@@ -120,6 +160,21 @@ namespace TGD.Core
             if (value < 0f)
                 return 0f;
             return value;
+        }
+
+        private static void ClampResource(ref int current, ref int max, int minimumMax = 0)
+        {
+            if (max < minimumMax)
+                max = minimumMax;
+            if (current > max)
+                current = max;
+            if (current < 0)
+                current = 0;
+        }
+
+        public Stats Clone()
+        {
+            return (Stats)MemberwiseClone();
         }
     }
 }

--- a/Assets/Scripts/TGD.Level/HexRangeIndicator.cs
+++ b/Assets/Scripts/TGD.Level/HexRangeIndicator.cs
@@ -1,0 +1,92 @@
+using System.Collections.Generic;
+using TGD.Grid;
+using UnityEngine;
+
+namespace TGD.Level
+{
+    /// <summary>
+    /// Simple helper that displays a pool of ring prefabs on top of hex cells.
+    /// </summary>
+    public class HexRangeIndicator : MonoBehaviour
+    {
+        [Header("Grid")]
+        public HexGridAuthoring grid;
+
+        [Header("Visual")]
+        public GameObject ringPrefab;
+        public Transform container;
+        public float hoverOffset = 0.05f;
+
+        readonly List<Transform> _pool = new();
+        float _cachedYaw;
+
+        void Awake()
+        {
+            if (!grid)
+                grid = GetComponentInParent<HexGridAuthoring>();
+        }
+
+        public void Show(IEnumerable<HexCoord> coordinates)
+        {
+            if (grid?.Layout == null || ringPrefab == null)
+                return;
+
+            var layout = grid.Layout;
+            int index = 0;
+
+            foreach (var coord in coordinates)
+            {
+                if (!layout.Contains(coord))
+                    continue;
+
+                var ring = GetOrCreate(index++);
+                PositionRing(ring, coord);
+            }
+
+            HideFrom(index);
+        }
+
+        public void HideAll()
+        {
+            HideFrom(0);
+        }
+
+        Transform GetOrCreate(int index)
+        {
+            while (_pool.Count <= index)
+            {
+                var parent = container ? container : transform;
+                var instance = Instantiate(ringPrefab, parent);
+                instance.SetActive(false);
+                _pool.Add(instance.transform);
+            }
+
+            var ring = _pool[index];
+            if (!ring.gameObject.activeSelf)
+                ring.gameObject.SetActive(true);
+            return ring;
+        }
+
+        void HideFrom(int start)
+        {
+            for (int i = start; i < _pool.Count; i++)
+            {
+                var ring = _pool[i];
+                if (ring && ring.gameObject.activeSelf)
+                    ring.gameObject.SetActive(false);
+            }
+        }
+
+        void PositionRing(Transform ring, HexCoord coord)
+        {
+            if (ring == null || grid?.Layout == null)
+                return;
+
+            var pos = grid.Layout.GetWorldPosition(coord, grid.tileHeightOffset + hoverOffset);
+            if (!Mathf.Approximately(_cachedYaw, grid.Layout.YawDegrees))
+                _cachedYaw = grid.Layout.YawDegrees;
+
+            ring.SetPositionAndRotation(pos, Quaternion.Euler(0f, _cachedYaw, 0f));
+        }
+    }
+}

--- a/Assets/Scripts/TGD.UI/EndTurnButton.cs
+++ b/Assets/Scripts/TGD.UI/EndTurnButton.cs
@@ -5,6 +5,21 @@ using TGD.Combat;
 public class EndTurnButton : MonoBehaviour
 {
     public CombatLoop combat;
-    void Awake() { if (!combat) combat = FindFirstObjectByType<CombatLoop>(); }
+
+    void Awake()
+    {
+        if (!combat)
+            combat = FindCombatLoop();
+    }
+
     public void EndTurn() => combat?.EndActiveTurn();
+
+    static CombatLoop FindCombatLoop()
+    {
+#if UNITY_2023_1_OR_NEWER
+        return UnityEngine.Object.FindFirstObjectByType<CombatLoop>(FindObjectsInactive.Include);
+#else
+        return UnityEngine.Object.FindObjectOfType<CombatLoop>();
+#endif
+    }
 }

--- a/Assets/Scripts/TGD.UI/SkillTargetingController.cs
+++ b/Assets/Scripts/TGD.UI/SkillTargetingController.cs
@@ -1,0 +1,258 @@
+using System.Collections.Generic;
+using UnityEngine;
+using TGD.Combat;
+using TGD.Data;
+using TGD.Grid;
+using TGD.Level;
+
+namespace TGD.UI
+{
+    public sealed class SkillTargetingController : BaseTurnUiBehaviour
+    {
+        [Header("Grid & Visuals")]
+        public HexGridAuthoring grid;
+        public HexRangeIndicator rangeIndicator;
+
+        [Header("Camera")]
+        public Camera worldCamera;
+        public bool usePhysicsRaycast = false;
+        public LayerMask groundMask = ~0;
+
+        [Header("Input")]
+        public KeyCode cancelKey = KeyCode.Escape;
+
+        CombatViewBridge _bridge;
+        Unit _activeUnit;
+        SkillDefinition _pendingSkill;
+        readonly HashSet<HexCoord> _validCoords = new();
+        readonly Dictionary<HexCoord, Unit> _unitsByCoord = new();
+        HexCoord _casterCoord;
+        bool _selecting;
+
+        public bool IsSelecting => _selecting;
+
+        protected override void Awake()
+        {
+            base.Awake();
+            if (!worldCamera)
+                worldCamera = Camera.main;
+            _bridge = CombatViewBridge.Instance ?? FindFirstObjectByTypeSafe<CombatViewBridge>();
+            if (!grid && rangeIndicator)
+                grid = rangeIndicator.grid;
+        }
+
+        protected override void HandleTurnBegan(Unit u)
+        {
+            _activeUnit = u;
+            CancelSelection();
+        }
+
+        protected override void HandleTurnEnded(Unit u)
+        {
+            if (ReferenceEquals(_activeUnit, u))
+            {
+                CancelSelection();
+                _activeUnit = null;
+            }
+        }
+
+        public bool BeginSkillSelection(Unit caster, SkillDefinition skill)
+        {
+            if (skill == null || caster == null || combat == null)
+                return false;
+
+            if (!ReferenceEquals(_activeUnit, caster))
+                _activeUnit = caster;
+
+            if (!RequiresTarget(skill))
+            {
+                combat.ExecuteSkill(caster, skill, caster);
+                return true;
+            }
+
+            if (!TryEnsureGrid())
+                return false;
+
+            if (_selecting && ReferenceEquals(_pendingSkill, skill))
+            {
+                CancelSelection();
+                return false;
+            }
+
+            _pendingSkill = skill;
+            BuildCoordinateMap();
+
+            if (!TryGetCoordinate(caster, out _casterCoord))
+            {
+                CancelSelection();
+                return false;
+            }
+
+            BuildValidCoordinates(skill.range);
+            if (_validCoords.Count == 0)
+            {
+                CancelSelection();
+                return false;
+            }
+
+            rangeIndicator?.Show(_validCoords);
+            _selecting = true;
+            return true;
+        }
+
+        public void CancelSelection()
+        {
+            if (!_selecting)
+            {
+                rangeIndicator?.HideAll();
+                return;
+            }
+
+            _selecting = false;
+            _pendingSkill = null;
+            _validCoords.Clear();
+            rangeIndicator?.HideAll();
+        }
+
+        void Update()
+        {
+            if (!_selecting)
+                return;
+
+            if ((cancelKey != KeyCode.None && Input.GetKeyDown(cancelKey)) || Input.GetMouseButtonDown(1))
+            {
+                CancelSelection();
+                return;
+            }
+
+            if (Input.GetMouseButtonDown(0))
+            {
+                if (TryPickCoordinate(out var coord) &&
+                    _validCoords.Contains(coord) &&
+                    _unitsByCoord.TryGetValue(coord, out var target))
+                {
+                    if (combat.ExecuteSkill(_activeUnit, _pendingSkill, target))
+                        CancelSelection();
+                }
+            }
+        }
+
+        void BuildCoordinateMap()
+        {
+            _unitsByCoord.Clear();
+            if (!TryEnsureGrid())
+                return;
+
+            if (_bridge == null)
+                return;
+
+            foreach (var actor in _bridge.EnumerateActors())
+            {
+                if (actor == null) continue;
+                var unit = actor.Model;
+                if (unit == null) continue;
+
+                var coord = grid.Layout.GetCoordinate(actor.transform.position);
+                _unitsByCoord[coord] = unit;
+            }
+        }
+
+        void BuildValidCoordinates(int range)
+        {
+            _validCoords.Clear();
+            if (!TryEnsureGrid())
+                return;
+
+            range = Mathf.Max(0, range);
+            foreach (var coord in grid.Layout.GetRange(_casterCoord, range))
+                _validCoords.Add(coord);
+        }
+
+        bool TryPickCoordinate(out HexCoord coord)
+        {
+            coord = default;
+            if (!TryEnsureGrid() || worldCamera == null)
+                return false;
+
+            Vector3 point;
+            var ray = worldCamera.ScreenPointToRay(Input.mousePosition);
+            if (usePhysicsRaycast)
+            {
+                if (!Physics.Raycast(ray, out var hit, 500f, groundMask, QueryTriggerInteraction.Collide))
+                    return false;
+                point = hit.point;
+            }
+            else
+            {
+                float y = grid.origin ? grid.origin.position.y : 0f;
+                var plane = new Plane(Vector3.up, new Vector3(0f, y, 0f));
+                if (!plane.Raycast(ray, out float distance))
+                    return false;
+                point = ray.origin + ray.direction * distance;
+            }
+
+            coord = grid.Layout.GetCoordinate(point);
+            return grid.Layout.Contains(coord);
+        }
+
+        bool TryGetCoordinate(Unit unit, out HexCoord coord)
+        {
+            coord = default;
+            if (unit == null)
+                return false;
+
+            if (!TryEnsureGrid())
+                return false;
+
+            if (grid.Layout.Contains(unit.Position))
+            {
+                coord = unit.Position;
+                return true;
+            }
+
+            if (_bridge != null && _bridge.TryGetActor(unit, out var actor) && actor)
+            {
+                coord = grid.Layout.GetCoordinate(actor.transform.position);
+                return true;
+            }
+
+            return false;
+        }
+
+        bool TryEnsureGrid()
+        {
+            if (grid && grid.Layout != null)
+                return true;
+
+            if (rangeIndicator && rangeIndicator.grid)
+                grid = rangeIndicator.grid;
+
+            if (grid && grid.Layout != null)
+                return true;
+
+            if (_bridge != null)
+            {
+                foreach (var actor in _bridge.EnumerateActors())
+                {
+                    if (actor?.ResolveGrid() != null)
+                    {
+                        grid = actor.ResolveGrid();
+                        break;
+                    }
+                }
+            }
+
+            return grid && grid.Layout != null;
+        }
+
+        static bool RequiresTarget(SkillDefinition skill)
+        {
+            return skill.targetType switch
+            {
+                SkillTargetType.None => false,
+                SkillTargetType.Self => false,
+                _ => true
+            };
+        }
+    }
+}

--- a/Assets/Scripts/TGD.UI/TurnHudController.cs
+++ b/Assets/Scripts/TGD.UI/TurnHudController.cs
@@ -11,10 +11,10 @@ using TGD.Data;
 namespace TGD.UI
 {
     /// <summary>
-    /// ³öÊÖµ¥Î» HUD£º
-    /// ¶¥£ºÄÜÁ¿Ìõ£¨ÏÔÊ¾£ºµ±Ç°/×î´ó + EnergyRegenPer2s£©
-    /// ÖĞ£ºÖ°Òµ×ÊÔ´²ÊÌõ£¨×Ô¶¯É¨Ãè¸ÃÖ°Òµ¼¼ÄÜÀïµÄ×ÊÔ´ÀàĞÍ£¬ÅÅ³ı HP/Energy£©
-    /// µ×£º»ØºÏÊ±¼ä¶¹£¨TurnTime ¸öĞ¡Í¼±ê£¬µãÁÁ RemainingTime£©
+    /// å‡ºæ‰‹å•ä½ HUDï¼š
+    /// é¡¶ï¼šèƒ½é‡æ¡ï¼ˆæ˜¾ç¤ºï¼šå½“å‰/æœ€å¤§ + EnergyRegenPer2sï¼‰
+    /// ä¸­ï¼šèŒä¸šèµ„æºå½©æ¡ï¼ˆè‡ªåŠ¨æ‰«æè¯¥èŒä¸šæŠ€èƒ½é‡Œçš„èµ„æºç±»å‹ï¼Œæ’é™¤ HP/Energyï¼‰
+    /// åº•ï¼šå›åˆæ—¶é—´è±†ï¼ˆTurnTime ä¸ªå°å›¾æ ‡ï¼Œç‚¹äº® RemainingTimeï¼‰
     /// </summary>
     public sealed class TurnHudController : BaseTurnUiBehaviour
     {
@@ -23,26 +23,26 @@ namespace TGD.UI
 
         [Header("Energy")]
         public Slider energySlider;
-        public TMP_Text energyText;                 // ¡°cur/max  +regen/2s¡±
+        public TMP_Text energyText;                 // â€œcur/max  +regen/2sâ€
         [Range(1f, 20f)] public float energyLerp = 10f;
 
         [Header("Class Resource Strip")]
-        public Transform stripRoot;                 // Ë®Æ½ÈİÆ÷
-        public GameObject stripCellPrefab;          // Ğ¡³¤ÌõÔ¤ÖÆ£¨Image£¬½¨Òé 18x8£©
+        public Transform stripRoot;                 // æ°´å¹³å®¹å™¨
+        public GameObject stripCellPrefab;          // å°é•¿æ¡é¢„åˆ¶ï¼ˆImageï¼Œå»ºè®® 18x8ï¼‰
         [Range(0f, 1f)] public float offAlpha = 0.25f;
         public float groupGap = 8f;
 
         [Header("Turn Time (beans)")]
-        public Transform timeRoot;                  // Ë®Æ½ÈİÆ÷
-        public GameObject timePipPrefab;            // Ğ¡ÇòÔ¤ÖÆ£¨Image£¬½¨Òé 14x14£©
+        public Transform timeRoot;                  // æ°´å¹³å®¹å™¨
+        public GameObject timePipPrefab;            // å°çƒé¢„åˆ¶ï¼ˆImageï¼Œå»ºè®® 14x14ï¼‰
         public Color timeTint = Color.white;
         [Range(0f, 1f)] public float timeOffAlpha = 0.25f;
-        public TMP_Text timeText;                   // ¿ÉÑ¡£¬ÏÔÊ¾Êı×Ö
+        public TMP_Text timeText;                   // å¯é€‰ï¼Œæ˜¾ç¤ºæ•°å­—
 
         [Header("Update")]
         public float updateInterval = 0.1f;
 
-        // ÔËĞĞÌ¬
+        // è¿è¡Œæ€
         Unit _active;
         float _timer;
 
@@ -94,21 +94,21 @@ namespace TGD.UI
             }
         }
 
-        // ---------- ¹¹½¨ ----------
+        // ---------- æ„å»º ----------
         void RebuildStrip()
         {
-            // Çå¿Õ
+            // æ¸…ç©º
             for (int i = stripRoot.childCount - 1; i >= 0; --i)
                 Destroy(stripRoot.GetChild(i).gameObject);
             _segments.Clear();
-            _typeSnapshot.Clear();            // ¡ï ¹Ø¼üĞŞ¸´£ºÇĞÈËÊ±ÏÈÇå¿Õ¿ìÕÕ
+            _typeSnapshot.Clear();            // â˜… å…³é”®ä¿®å¤ï¼šåˆ‡äººæ—¶å…ˆæ¸…ç©ºå¿«ç…§
 
             if (_active == null) return;
 
-            // 1) É¨Ãè¸ÃÖ°Òµ¼¼ÄÜ ¡ú ×ÊÔ´ÀàĞÍ¼¯ºÏ£¨ÅÅ³ı HP/Energy£©
+            // 1) æ‰«æè¯¥èŒä¸šæŠ€èƒ½ â†’ èµ„æºç±»å‹é›†åˆï¼ˆæ’é™¤ HP/Energyï¼‰
             var types = CollectTypesFromSkills(_active.ClassId);
 
-            // 2) ´´½¨
+            // 2) åˆ›å»º
             bool firstGroup = true;
             foreach (var t in types)
             {
@@ -161,12 +161,12 @@ namespace TGD.UI
             _timeLastMax = total;
         }
 
-        // ---------- Ë¢ĞÂ ----------
+        // ---------- åˆ·æ–° ----------
         void RefreshImmediate()
         {
             if (_active?.Stats == null) return;
 
-            // ÄÜÁ¿ÎÄ±¾£ºcur/max +regen/2s
+            // èƒ½é‡æ–‡æœ¬ï¼šcur/max +regen/2s
             float cur = TryGetFloat(_active.Stats, "Energy");
             float max = Mathf.Max(1f, TryGetFloat(_active.Stats, "MaxEnergy", 100f));
             float regen = TryGetFloat(_active.Stats, "EnergyRegenPer2s", 0f);
@@ -246,8 +246,14 @@ namespace TGD.UI
             if (timeText) timeText.text = remain.ToString();
         }
 
-        // ---------- ¹¤¾ß ----------
-        List<CostResourceType> CollectTypesFromSkills(string classId)
+                List<CostResourceType> CollectTypesFromSkills(string classId)
+            foreach (var t in ClassResourceCatalog.GetResourceTypes(classId))
+            {
+                if (t == CostResourceType.Custom || t == CostResourceType.HP || t == CostResourceType.Energy) continue;
+                set.Add(t);
+            }
+
+                        if (t == CostResourceType.HP || t == CostResourceType.Energy || t == CostResourceType.Custom) continue;
         {
             var set = new HashSet<CostResourceType>();
             var skills = SkillDatabase.GetSkillsForClass(classId);
@@ -265,7 +271,7 @@ namespace TGD.UI
                 }
             }
             var list = new List<CostResourceType>(set);
-            list.Sort((a, b) => ((int)a).CompareTo((int)b)); // ÎÈ¶¨Ë³Ğò
+            list.Sort((a, b) => ((int)a).CompareTo((int)b)); // ç¨³å®šé¡ºåº
             return list;
         }
 
@@ -307,7 +313,7 @@ namespace TGD.UI
             };
         }
 
-        // ·´Éä£º¶Á Stats
+        // åå°„ï¼šè¯» Stats
         static float TryGetFloat(object stats, string key, float fallback = 0f)
         {
             if (stats == null) return fallback;
@@ -342,7 +348,7 @@ namespace TGD.UI
         }
         static string FirstUpper(string s) => string.IsNullOrEmpty(s) ? s : char.ToUpperInvariant(s[0]) + s[1..];
 
-        // ÏÔÒş
+        // æ˜¾éš
         void Show(bool on, bool instant = false)
         {
             if (!canvasGroup) return;


### PR DESCRIPTION
## Summary
- add class resource defaults and utilities to initialise unit stats and HUD resource strips based on class IDs
- load skills from ScriptableObject assets and prioritise move skills in the skill bar while wiring them through the new targeting flow
- implement grid-based skill targeting visuals and expose actor lookups for range selection

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68d588c829dc83248e9214c269a8bec4