### PR TITLE
Refine combat UI subscriptions and skill ordering

### DIFF
--- a/Assets/Scripts/TGD.UI/BaseTurnUIBehaviour.cs
+++ b/Assets/Scripts/TGD.UI/BaseTurnUIBehaviour.cs
@@ -5,34 +5,93 @@ using TGD.Combat;
 namespace TGD.UI
 {
     /// <summary>
-    /// Í³Ò»£º²éÕÒ CombatLoop¡¢¶©ÔÄ/ÍË¶©»ØºÏÊÂ¼ş¡¢ÔÚÆôÓÃÊ±ÈôÒÑÓĞ¼¤»îµ¥Î»Ôò²¹Ò»´Î»Øµ÷¡£
+    /// ç»Ÿä¸€ï¼šæŸ¥æ‰¾ CombatLoopï¼Œè®¢é˜…æˆ˜æ–—æ€»çº¿çš„å›åˆäº‹ä»¶ï¼Œå¯ç”¨æ—¶è‹¥å·²æœ‰æ¿€æ´»å•ä½åˆ™è¡¥ä¸€æ¬¡å›è°ƒã€‚
     /// </summary>
     public abstract class BaseTurnUiBehaviour : MonoBehaviour
     {
         [Header("Combat (optional)")]
         [SerializeField] protected CombatLoop combat;
 
+        ICombatEventBus _eventBus;
+        bool _pendingInitialSync;
+
         protected virtual void Awake()
         {
-            if (!combat) combat = FindFirstObjectByTypeSafe<CombatLoop>();
+            if (!combat)
+                combat = FindFirstObjectByTypeSafe<CombatLoop>();
+            _pendingInitialSync = true;
         }
 
         protected virtual void OnEnable()
         {
-            if (!combat) return;
-            combat.OnTurnBegan += HandleTurnBegan;
-            combat.OnTurnEnded += HandleTurnEnded;
-
-            // ³¡¾°ÒÑÔÚÅÜ£º²¹Ò»´Î
-            var cur = combat.GetActiveUnit();
-            if (cur != null) HandleTurnBegan(cur);
+            RefreshCombatReference();
+            TryInitialSync();
         }
 
         protected virtual void OnDisable()
         {
-            if (!combat) return;
-            combat.OnTurnBegan -= HandleTurnBegan;
-            combat.OnTurnEnded -= HandleTurnEnded;
+            SubscribeEventBus(null);
+        }
+
+        protected virtual void LateUpdate()
+        {
+            RefreshCombatReference();
+            TryInitialSync();
+        }
+
+        void RefreshCombatReference()
+        {
+            if (!combat)
+                combat = FindFirstObjectByTypeSafe<CombatLoop>();
+
+            SubscribeEventBus(combat ? combat.EventBus : null);
+        }
+
+        void SubscribeEventBus(ICombatEventBus next)
+        {
+            if (ReferenceEquals(next, _eventBus))
+                return;
+
+            if (_eventBus != null)
+            {
+                _eventBus.OnTurnBegin -= OnTurnBeginEvent;
+                _eventBus.OnTurnEnd -= OnTurnEndEvent;
+            }
+
+            _eventBus = next;
+
+            if (_eventBus != null)
+            {
+                _eventBus.OnTurnBegin += OnTurnBeginEvent;
+                _eventBus.OnTurnEnd += OnTurnEndEvent;
+                _pendingInitialSync = true;
+            }
+        }
+
+        void TryInitialSync()
+        {
+            if (!_pendingInitialSync || combat == null)
+                return;
+
+            var cur = combat.GetActiveUnit();
+            if (cur != null)
+                HandleTurnBegan(cur);
+
+            _pendingInitialSync = false;
+        }
+
+        void OnTurnBeginEvent(Unit unit)
+        {
+            if (unit == null)
+                return;
+            HandleTurnBegan(unit);
+        }
+
+        void OnTurnEndEvent(Unit unit)
+        {
+            if (unit == null)
+                return;
+            HandleTurnEnded(unit);
         }
 
         protected abstract void HandleTurnBegan(Unit u);


### PR DESCRIPTION
## Summary
- switch BaseTurnUiBehaviour to subscribe to the combat event bus and resync the active unit automatically
- rebuild SkillTargetingController coordinate caches from Unit.Position/event bus data so the range indicator follows the caster
- reimplement SkillBarController skill ordering to pull class skill definitions, lock Move to slot 1, and fill remaining slots by id/color rules while avoiding duplicate variants

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68d5dc1f42348324ac980a107325d0f6