### PR TITLE
Refine movement simulation to stabilize refunds

### DIFF
--- a/Assets/Scripts/TGD.CombatV2/System/AttackSystem/AttackPlannerV2.cs
+++ b/Assets/Scripts/TGD.CombatV2/System/AttackSystem/AttackPlannerV2.cs
@@ -11,9 +11,9 @@ namespace TGD.CombatV2
         {
             public Hex target;
             public Hex chosenLanding;
-            public List<Hex> rawShortestPath;   // 起点→落脚点（无加权）
-            public List<Hex> truncatedPath;     // 预算截断后的执行路径
-            public bool canHit;                 // 是否到达落脚点
+            public List<Hex> rawShortestPath;
+            public List<Hex> truncatedPath;
+            public bool canHit;
             public float usedSeconds;
             public int refundedSeconds;
         }
@@ -34,7 +34,6 @@ namespace TGD.CombatV2
             var plan = new Plan { target = target };
             if (layout == null || occ == null) return plan;
 
-            // 1) 候选落脚点（整组落位；pit 不能站）
             var candidates = new List<Hex>();
             foreach (var h in Hex.Ring(target, meleeRange))
             {
@@ -45,14 +44,16 @@ namespace TGD.CombatV2
             }
             if (candidates.Count == 0) return plan;
 
-            // 2) 最短路径（不考虑环境），中途不穿人/不踩 pit
-            List<Hex> best = null; int bestLen = int.MaxValue; Hex chosen = default;
+            List<Hex> best = null;
+            int bestLen = int.MaxValue;
+            Hex chosen = default;
 
             foreach (var landing in candidates)
             {
                 var raw = ShortestPath(
-                    start, landing,
-                    isBlocked: (cell) =>
+                    start,
+                    landing,
+                    cell =>
                     {
                         if (!layout.Contains(cell)) return true;
                         if (isPit != null && isPit(cell)) return true;
@@ -63,7 +64,9 @@ namespace TGD.CombatV2
 
                 if (raw != null && raw.Count > 0 && raw.Count < bestLen)
                 {
-                    best = raw; bestLen = raw.Count; chosen = landing;
+                    best = raw;
+                    bestLen = raw.Count;
+                    chosen = landing;
                 }
             }
 
@@ -71,10 +74,13 @@ namespace TGD.CombatV2
             plan.rawShortestPath = best;
             if (best == null || best.Count < 2) return plan;
 
-            // 3) 执行期：用 MoveSimulator 截断/返还
+            float startEnv = getEnvMult != null ? getEnvMult(best[0]) : 1f;
+            startEnv = Mathf.Clamp(startEnv, 0.1f, 5f);
+
             var sim = MoveSimulator.Run(
                 best,
                 baseMoveRate,
+                startEnv,
                 Mathf.Max(0, budgetSeconds),
                 getEnvMult,
                 refundThresholdSeconds
@@ -83,17 +89,17 @@ namespace TGD.CombatV2
             plan.truncatedPath = sim.ReachedPath;
             plan.usedSeconds = sim.UsedSeconds;
             plan.refundedSeconds = sim.RefundedSeconds;
-            plan.canHit = (sim.ReachedPath != null && sim.ReachedPath.Count == best.Count);
+            plan.canHit = sim.ReachedPath != null && sim.ReachedPath.Count == best.Count;
 
             return plan;
         }
 
-        // —— 内置简单 BFS（无加权） —— //
         static List<Hex> ShortestPath(Hex start, Hex goal, System.Func<Hex, bool> isBlocked)
         {
             var q = new Queue<Hex>();
             var came = new Dictionary<Hex, Hex>();
-            q.Enqueue(start); came[start] = start;
+            q.Enqueue(start);
+            came[start] = start;
 
             while (q.Count > 0)
             {
@@ -103,14 +109,19 @@ namespace TGD.CombatV2
                 {
                     if (came.ContainsKey(nb)) continue;
                     if (isBlocked != null && isBlocked(nb)) continue;
-                    came[nb] = cur; q.Enqueue(nb);
+                    came[nb] = cur;
+                    q.Enqueue(nb);
                 }
             }
 
             if (!came.ContainsKey(goal)) return null;
             var path = new List<Hex> { goal };
             var c = goal;
-            while (!c.Equals(start)) { c = came[c]; path.Add(c); }
+            while (!c.Equals(start))
+            {
+                c = came[c];
+                path.Add(c);
+            }
             path.Reverse();
             return path;
         }

--- a/Assets/Scripts/TGD.HexBoard/MoveSimulator.cs
+++ b/Assets/Scripts/TGD.HexBoard/MoveSimulator.cs
@@ -5,161 +5,89 @@ using UnityEngine;
 
 namespace TGD.HexBoard
 {
-    /// 执行期逐格模拟（v2，加法口径）：
-    /// - 环境倍率先转成“基于基础移速”的加法增量： envAdd = floor(baseBaseMoveRate * (mult - 1))
-    /// - 本步有效 MR = max(1, effectiveBaseNoEnv + envAdd)
-    /// - 返还按“计划步长”（不含环境）与“实际步长”的差额累计
     public static class MoveSimulator
     {
         public sealed class Result
         {
             public readonly List<Hex> ReachedPath = new();
-            public float UsedSeconds;      // float 便于日志；对外扣费仍用整秒
+            public float UsedSeconds;
             public int RefundedSeconds;
             public bool Arrived;
         }
 
+        const float MR_MIN = 1f;
+        const float MR_MAX = 12f;
+        const float ENV_MIN = 0.1f;
+        const float ENV_MAX = 5f;
+
         /// <summary>
-        /// 统一新口径（乘后再加）：
-        /// effMR(step) = baseR * noEnvMultNow * fromMult + flatAfterNow
-        /// - noEnvMultNow = buffMult_now * stickyMult_now（不含地形）
-        /// - fromMult: 本步起点格的地形倍率
+        /// Accurate move simulation that mirrors the preview calculation.
+        /// MR_base = clamp(baseMoveRateNoEnv, [MR_MIN, MR_MAX])
+        /// effMR(step) = clamp(MR_base * envMult(from), [MR_MIN, MR_MAX])
+        /// Refund is measured against the planned step cost (MR_click).
         /// </summary>
-        public static Result RunMultiThenFlat(
-            IList<Hex> path,
-            int baseR,
-            float noEnvMultNow,          // buff * sticky（不含地形）
-            float flatAfterNow,          // 高贵平加（乘法后再加）
-            int budgetSeconds,           // 整秒预算
-            System.Func<Hex, float> getEnvMult, // 地形倍率（from）
-            float refundThresholdSeconds = 0.8f,
-            bool debug = false)
-        {
-            var res = new Result();
-            if (path == null || path.Count == 0 || baseR <= 0) return res;
-
-            res.ReachedPath.Add(path[0]);
-            float budget = Mathf.Max(0f, budgetSeconds);
-            float saved = 0f;
-            int refunds = 0;
-
-            // “计划步长成本”：不含地形时的基线
-            float baseMR_noEnv = StatsMathV2.MR_MultiThenFlat(baseR, new float[] { noEnvMultNow }, flatAfterNow);
-            float baseStepCost = 1f / Mathf.Max(0.01f, baseMR_noEnv);
-
-            for (int i = 1; i < path.Count; i++)
-            {
-                var from = path[i - 1];
-                var to = path[i];
-
-                float fromMult = Mathf.Clamp(getEnvMult != null ? getEnvMult(from) : 1f, 0.01f, 100f);
-                float effMR = StatsMathV2.MR_MultiThenFlat(baseR, new float[] { noEnvMultNow * fromMult }, flatAfterNow);
-                float actualCost = 1f / Mathf.Max(0.01f, effMR);
-
-                if (budget + 1e-6f < actualCost) break;
-
-                budget -= actualCost;
-                res.ReachedPath.Add(to);
-
-                float stepSaved = Mathf.Max(0f, baseStepCost - actualCost);
-                saved += stepSaved;
-
-                while (saved >= refundThresholdSeconds)
-                {
-                    saved -= refundThresholdSeconds;
-                    refunds += 1;
-                    budget += 1f;
-                    if (debug) Debug.Log($"[MoveSim·MultiThenFlat] refund+1 thr={refundThresholdSeconds:F2} savedLeft={saved:F3} budget={budget:F3} effMR={effMR:F2}");
-                }
-
-                if (debug)
-                    Debug.Log($"[MoveSim·Step] i={i} from={from} effMR={effMR:F2} cost={actualCost:F3} budgetLeft={budget:F3}");
-            }
-
-            res.UsedSeconds = budgetSeconds - budget;
-            res.RefundedSeconds = refunds;
-            res.Arrived = (res.ReachedPath.Count == path.Count);
-            return res;
-        }
-
-
-        /// v2 正式版（加法口径）——已经废弃
-        public static Result RunAdditive(
-            IList<Hex> path,
-            int baseBaseMoveRate,                // 纯基础 MR：ctx.BaseMoveRate
-            int effectiveBaseNoEnv,              // 基础 +（基于基础的 buff/黏性等）后的 MR（不含环境）
-            int budgetSeconds,                   // 本次整秒预算
-            System.Func<Hex, float> getEnvMult,  // 环境倍率（>0）；按 from 取
-            float refundThresholdSeconds = 0.8f,
-            bool debug = false)
-        {
-            Debug.Log($"[MoveSim v2] additive=true asm={typeof(MoveSimulator).Assembly.FullName}");
-
-            var res = new Result();
-            if (path == null || path.Count == 0 || effectiveBaseNoEnv <= 0) return res;
-
-            // 起点先入，保证 Count>=1
-            res.ReachedPath.Add(path[0]);
-
-            float budget = Mathf.Max(0f, budgetSeconds);
-            float saved = 0f;
-            int refunds = 0;
-
-            // “计划步长”（不含环境），用于返还累积
-            float baseStepCost = 1f / Mathf.Max(0.01f, effectiveBaseNoEnv);
-
-            for (int i = 1; i < path.Count; i++)
-            {
-                var from = path[i - 1];
-                var to = path[i];
-
-                float multFrom = Mathf.Clamp(getEnvMult != null ? getEnvMult(from) : 1f, 0.1f, 5f);
-
-                // 把倍率转成“基于基础移速”的加法增量
-                int envAdd = Mathf.FloorToInt(Mathf.Max(1, baseBaseMoveRate) * (multFrom - 1f));
-                int effMR = Mathf.Max(1, effectiveBaseNoEnv + envAdd);      // 本步有效 MR（最低=1）
-                float actualCost = 1f / Mathf.Max(0.01f, effMR);              // 本步实际耗时
-
-                if (debug) Debug.Log($"[MoveSim+Add] step={i} from={from} mult={multFrom:F2} baseNoEnv={effectiveBaseNoEnv} envAdd={envAdd} effMR={effMR} cost={actualCost:F3} budget={budget:F3}");
-
-                if (budget + 1e-6f < actualCost) break; // 预算不足一格 → 截断
-
-                budget -= actualCost;
-                res.ReachedPath.Add(to);
-
-                // 返还累积（计划-实际）
-                float stepSaved = Mathf.Max(0f, baseStepCost - actualCost);
-                saved += stepSaved;
-                while (saved >= refundThresholdSeconds)
-                {
-                    saved -= refundThresholdSeconds;
-                    refunds += 1;
-                    budget += 1f;
-                    if (debug) Debug.Log($"[MoveSim+Add] refund+1 thr={refundThresholdSeconds:F2} saved={saved:F3} budg={budget:F3} effMR={effMR}");
-                }
-            }
-
-            res.UsedSeconds = budgetSeconds - budget;
-            res.RefundedSeconds = refunds;
-            res.Arrived = (res.ReachedPath.Count == path.Count);
-            return res;
-        }
-
-        /// 兼容包装（旧签名）：把 baseMoveRate 视为“不含环境的有效 MR”，
-        /// 同时用 floor(baseMoveRate) 近似 baseBaseMoveRate。
-        /// 建议尽快把调用点切到 RunAdditive(...) 并传入真实 baseBaseMoveRate。
         public static Result Run(
             IList<Hex> path,
-            float baseMoveRate,                 // 视为“不含环境的有效 MR”
+            float baseMoveRateNoEnv,
+            float startEnvMultiplier,
             int budgetSeconds,
             System.Func<Hex, float> getEnvMult,
             float refundThresholdSeconds = 0.8f,
             bool debug = false)
         {
-            int effectiveNoEnv = Mathf.Max(1, Mathf.FloorToInt(baseMoveRate));
-            int baseBaseMoveRate = effectiveNoEnv; // 近似；推荐调用点改为传 ctx.BaseMoveRate
-            if (debug) Debug.LogWarning("[MoveSim v2] Run(legacy) wrapper in use → please migrate to RunAdditive(...) with ctx.BaseMoveRate.");
-            return RunAdditive(path, baseBaseMoveRate, effectiveNoEnv, budgetSeconds, getEnvMult, refundThresholdSeconds, debug);
+            var res = new Result();
+            if (path == null || path.Count == 0) return res;
+
+            float mrBase = Mathf.Clamp(baseMoveRateNoEnv, MR_MIN, MR_MAX);
+            float startEnv = Mathf.Clamp(startEnvMultiplier, ENV_MIN, ENV_MAX);
+            float mrClick = Mathf.Clamp(mrBase * startEnv, MR_MIN, MR_MAX);
+
+            res.ReachedPath.Add(path[0]);
+
+            float budget = Mathf.Max(0f, budgetSeconds);
+            float saved = 0f;
+            float used = 0f;
+            int refunds = 0;
+
+            float baseStepCost = 1f / Mathf.Max(MR_MIN, mrClick);
+
+            for (int i = 1; i < path.Count; i++)
+            {
+                var from = path[i - 1];
+                var to = path[i];
+
+                float envMult = getEnvMult != null ? getEnvMult(from) : 1f;
+                envMult = Mathf.Clamp(envMult, ENV_MIN, ENV_MAX);
+
+                float effMR = Mathf.Clamp(mrBase * envMult, MR_MIN, MR_MAX);
+                float stepCost = 1f / Mathf.Max(MR_MIN, effMR);
+
+                if (budget + 1e-6f < stepCost) break;
+
+                budget -= stepCost;
+                used += stepCost;
+                res.ReachedPath.Add(to);
+
+                float stepSaved = Mathf.Max(0f, baseStepCost - stepCost);
+                saved += stepSaved;
+
+                while (saved >= refundThresholdSeconds)
+                {
+                    saved -= refundThresholdSeconds;
+                    refunds += 1;
+                    budget += 1f;
+                    if (debug)
+                        Debug.Log($"[MoveSim-Refund] +1s thr={refundThresholdSeconds:F2} savedLeft={saved:F3} budget={budget:F3}");
+                }
+
+                if (debug)
+                    Debug.Log($"[MoveSim-Step] i={i} from={from} effMR={effMR:F2} cost={stepCost:F3} budgetLeft={budget:F3}");
+            }
+
+            res.UsedSeconds = Mathf.Max(0f, used);
+            res.RefundedSeconds = refunds;
+            res.Arrived = (res.ReachedPath.Count == path.Count);
+            return res;
         }
     }
 }


### PR DESCRIPTION
## Summary
- align the move preview and execution path in `HexClickMover` by sharing a rate snapshot and invoking the updated simulator while applying exclusive sticky effects
- replace the legacy `MoveSimulator` variants with a single multiplicative implementation that clamps speed values, accrues refunds correctly, and update the melee planner to supply the new inputs
- allow `HexEnvironmentSystem` to enforce sticky acceleration and optional sticky slows while `MoveRateStatusRuntime` manages haste/slow exclusivity

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68e38a6ff4d0832482d215d4698c724c